### PR TITLE
Add ET extrinsic to Block as a collection

### DIFF
--- a/internal/block/block.go
+++ b/internal/block/block.go
@@ -8,7 +8,7 @@ type Block struct {
 
 // Extrinsic represents the block extrinsic data
 type Extrinsic struct {
-	ET []*TicketProof
+	ET *TicketExtrinsic
 	EP *PreimageExtrinsic
 	ED *DisputeExtrinsic
 	EA *AssurancesExtrinsic

--- a/internal/block/ticket.go
+++ b/internal/block/ticket.go
@@ -18,3 +18,8 @@ type TicketProof struct {
 	EntryIndex uint8                 // r ∈ Nn (0, 1)
 	Proof      [ticketProofSize]byte // RingVRF proof
 }
+
+// TicketExtrinsic represents the E_T extrinsic
+type TicketExtrinsic struct {
+	TicketProofs []TicketProof
+}


### PR DESCRIPTION
Tiny refactor adding `TicketExtrinsic` type to match the rest of the extrinsics.