### PR TITLE
Add general serialization for natural numbers

### DIFF
--- a/pkg/serialization/codec/codec.go
+++ b/pkg/serialization/codec/codec.go
@@ -2,5 +2,7 @@ package codec
 
 type Codec interface {
 	Marshal(v interface{}) ([]byte, error)
+	MarshalGeneral(x uint64) ([]byte, error)
 	Unmarshal(data []byte, v interface{}) error
+	UnmarshalGeneral(data []byte, v *uint64) error
 }

--- a/pkg/serialization/codec/jam/errors.go
+++ b/pkg/serialization/codec/jam/errors.go
@@ -1,4 +1,4 @@
-package serialization
+package jam
 
 import "errors"
 

--- a/pkg/serialization/codec/jam/general_natural.go
+++ b/pkg/serialization/codec/jam/general_natural.go
@@ -1,4 +1,4 @@
-package serialization
+package jam
 
 import (
 	"encoding/binary"

--- a/pkg/serialization/codec/jam/general_natural_test.go
+++ b/pkg/serialization/codec/jam/general_natural_test.go
@@ -1,4 +1,4 @@
-package serialization
+package jam
 
 import (
 	"fmt"

--- a/pkg/serialization/codec/jam_codec.go
+++ b/pkg/serialization/codec/jam_codec.go
@@ -1,0 +1,34 @@
+package codec
+
+import (
+	"errors"
+	"github.com/eigerco/strawberry/pkg/serialization/codec/jam"
+)
+
+// JAMCodec implements the Codec interface for JSON encoding and decoding.
+type JAMCodec struct {
+	gn jam.GeneralNatural
+}
+
+// NewJamCodec initializes an instance of Jam codec
+func NewJamCodec() *JAMCodec {
+	return &JAMCodec{gn: jam.GeneralNatural{}}
+}
+
+func (j *JAMCodec) Marshal(v interface{}) ([]byte, error) {
+	// TODO
+	return nil, errors.New("not implemented")
+}
+
+func (j *JAMCodec) MarshalGeneral(v uint64) ([]byte, error) {
+	return j.gn.SerializeUint64(v), nil
+}
+
+func (j *JAMCodec) Unmarshal(data []byte, v interface{}) error {
+	// TODO
+	return errors.New("not implemented")
+}
+
+func (j *JAMCodec) UnmarshalGeneral(data []byte, v *uint64) error {
+	return j.gn.DeserializeUint64(data, v)
+}

--- a/pkg/serialization/codec/json_codec.go
+++ b/pkg/serialization/codec/json_codec.go
@@ -11,6 +11,14 @@ func (j *JSONCodec) Marshal(v interface{}) ([]byte, error) {
 	return json.Marshal(v)
 }
 
+func (j *JSONCodec) MarshalGeneral(v uint64) ([]byte, error) {
+	return json.Marshal(v)
+}
+
 func (j *JSONCodec) Unmarshal(data []byte, v interface{}) error {
+	return json.Unmarshal(data, v)
+}
+
+func (j *JSONCodec) UnmarshalGeneral(data []byte, v *uint64) error {
 	return json.Unmarshal(data, v)
 }

--- a/pkg/serialization/codec/scale_codec.go
+++ b/pkg/serialization/codec/scale_codec.go
@@ -9,6 +9,14 @@ func (s *SCALECodec) Marshal(v interface{}) ([]byte, error) {
 	return scale.Marshal(v)
 }
 
+func (j *SCALECodec) MarshalGeneral(v uint64) ([]byte, error) {
+	return scale.Marshal(v)
+}
+
 func (s *SCALECodec) Unmarshal(data []byte, v interface{}) error {
+	return scale.Unmarshal(data, v)
+}
+
+func (s *SCALECodec) UnmarshalGeneral(data []byte, v *uint64) error {
 	return scale.Unmarshal(data, v)
 }

--- a/pkg/serialization/serializer.go
+++ b/pkg/serialization/serializer.go
@@ -17,7 +17,17 @@ func (s *Serializer) Encode(v interface{}) ([]byte, error) {
 	return s.codec.Marshal(v)
 }
 
+// EncodeGeneral is specific encoding for natural numbers up to 2^64
+func (s *Serializer) EncodeGeneral(v uint64) ([]byte, error) {
+	return s.codec.MarshalGeneral(v)
+}
+
 // Decode deserializes the given data into the specified value using the codec.
 func (s *Serializer) Decode(data []byte, v interface{}) error {
 	return s.codec.Unmarshal(data, v)
+}
+
+// DecodeGeneral is specific decoding for natural numbers up to 2^64
+func (s *Serializer) DecodeGeneral(data []byte, v *uint64) error {
+	return s.codec.UnmarshalGeneral(data, v)
 }

--- a/pkg/serialization/serializer_test.go
+++ b/pkg/serialization/serializer_test.go
@@ -50,3 +50,20 @@ func TestSCALESerializer(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, example, decoded)
 }
+
+func TestGeneralSerializer(t *testing.T) {
+	jamCodec := codec.NewJamCodec()
+	serializer := serialization.NewSerializer(jamCodec)
+
+	// Test Encoding
+	v := uint64(127)
+	encoded, err := serializer.EncodeGeneral(v)
+	require.NoError(t, err)
+	require.Equal(t, []byte{127}, encoded)
+
+	// Test Decoding
+	var decoded uint64
+	err = serializer.DecodeGeneral(encoded, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, v, decoded)
+}


### PR DESCRIPTION
Adds general serialization for natural numbers up to 2^64 (275). I have added support only for uint64 for now.
part of this https://github.com/eigerco/strawberry/issues/6