### PR TITLE
Add byte slice/array & bool serialization

### DIFF
--- a/pkg/serialization/codec/jam/errors.go
+++ b/pkg/serialization/codec/jam/errors.go
@@ -1,8 +1,19 @@
 package jam
 
-import "errors"
+import (
+	"errors"
+)
 
 var (
 	// errFirstByteNineByteSerialization is returned when the first byte has wrong value in 9-byte serialization
 	errFirstByteNineByteSerialization = errors.New("expected first byte to be 255 for 9-byte serialization")
+
+	ErrEmptyData       = errors.New("empty data")
+	ErrNonPointerOrNil = errors.New("value must be a not-nil pointer")
+
+	ErrInvalidBooleanEncoding = errors.New("invalid boolean encoding")
+
+	ErrUnsupportedType     = "unsupported type: %T"
+	ErrArrayLengthMismatch = "array length mismatch: expected %d, got %d"
+	ErrDataLengthMismatch  = "data length mismatch: expected %d, got %d"
 )

--- a/pkg/serialization/codec/jam_codec.go
+++ b/pkg/serialization/codec/jam_codec.go
@@ -1,7 +1,9 @@
 package codec
 
 import (
-	"errors"
+	"fmt"
+	"reflect"
+
 	"github.com/eigerco/strawberry/pkg/serialization/codec/jam"
 )
 
@@ -17,9 +19,45 @@ func NewJamCodec[T Uint]() *JAMCodec[T] {
 	}
 }
 
+// Marshal encodes the given value into a byte slice.
 func (j *JAMCodec[T]) Marshal(v interface{}) ([]byte, error) {
-	// TODO
-	return nil, errors.New("not implemented")
+	val := reflect.ValueOf(v)
+
+	switch val.Kind() {
+	case reflect.Bool:
+		return j.encodeBool(val.Bool())
+	case reflect.Array, reflect.Slice:
+		if val.Type().Elem().Kind() == reflect.Uint8 {
+			return j.encodeByteSlice(val)
+		}
+	}
+
+	return nil, fmt.Errorf(jam.ErrUnsupportedType, v)
+}
+
+// Unmarshal decodes the given byte slice into the provided value.
+func (j *JAMCodec[T]) Unmarshal(data []byte, v interface{}) error {
+	if len(data) == 0 {
+		return jam.ErrEmptyData
+	}
+
+	val := reflect.ValueOf(v)
+	if val.Kind() != reflect.Ptr || val.IsNil() {
+		return jam.ErrNonPointerOrNil
+	}
+
+	elem := val.Elem()
+
+	switch elem.Kind() {
+	case reflect.Bool:
+		return j.decodeBool(data, elem)
+	case reflect.Slice, reflect.Array:
+		if elem.Type().Elem().Kind() == reflect.Uint8 {
+			return j.decodeByteSlice(data, elem)
+		}
+	}
+
+	return fmt.Errorf(jam.ErrUnsupportedType, v)
 }
 
 func (j *JAMCodec[T]) MarshalGeneral(v uint64) ([]byte, error) {
@@ -30,11 +68,6 @@ func (j *JAMCodec[T]) MarshalTrivialUint(x T, l uint8) ([]byte, error) {
 	return jam.SerializeTrivialNatural(x, l), nil
 }
 
-func (j *JAMCodec[T]) Unmarshal(data []byte, v interface{}) error {
-	// TODO
-	return errors.New("not implemented")
-}
-
 func (j *JAMCodec[T]) UnmarshalGeneral(data []byte, v *uint64) error {
 	return j.gn.DeserializeUint64(data, v)
 }
@@ -42,4 +75,76 @@ func (j *JAMCodec[T]) UnmarshalGeneral(data []byte, v *uint64) error {
 func (j *JAMCodec[T]) UnmarshalTrivialUint(data []byte, x *T) error {
 	jam.DeserializeTrivialNatural(data, x)
 	return nil
+}
+
+// encodeBool encodes a boolean value into a byte slice.
+func (j *JAMCodec[T]) encodeBool(b bool) ([]byte, error) {
+	if b {
+		return []byte{0x01}, nil // true -> 0x01
+	}
+	return []byte{0x00}, nil // false -> 0x00
+}
+
+// decodeBool decodes a boolean value from a byte slice.
+func (j *JAMCodec[T]) decodeBool(data []byte, elem reflect.Value) error {
+	if len(data) == 0 {
+		return jam.ErrEmptyData
+	}
+
+	switch data[0] {
+	case 0x01:
+		elem.SetBool(true)
+	case 0x00:
+		elem.SetBool(false)
+	default:
+		return jam.ErrInvalidBooleanEncoding
+	}
+	return nil
+}
+
+// encodeByteSlice encodes a byte slice or array into a byte slice with a prefixed length.
+func (j *JAMCodec[T]) encodeByteSlice(val reflect.Value) ([]byte, error) {
+	byteSlice, err := j.toByteSlice(val)
+	if err != nil {
+		return nil, err
+	}
+	// Prepend the length to the byte slice
+	result := append([]byte{byte(len(byteSlice))}, byteSlice...)
+	return result, nil
+}
+
+// decodeByteSlice decodes a byte slice or array from the given byte slice.
+func (j *JAMCodec[T]) decodeByteSlice(data []byte, elem reflect.Value) error {
+	length := int(data[0])
+
+	if len(data)-1 < length {
+		return fmt.Errorf(jam.ErrDataLengthMismatch, length, len(data)-1)
+	}
+
+	extractedData := data[len(data)-length:]
+
+	if elem.Kind() == reflect.Slice {
+		elem.SetBytes(extractedData)
+	} else if elem.Kind() == reflect.Array {
+		if elem.Len() != len(extractedData) {
+			return fmt.Errorf(jam.ErrArrayLengthMismatch, elem.Len(), len(extractedData))
+		}
+		reflect.Copy(elem, reflect.ValueOf(extractedData))
+	}
+
+	return nil
+}
+
+// toByteSlice converts an array or slice of bytes to a byte slice.
+func (j *JAMCodec[T]) toByteSlice(val reflect.Value) ([]byte, error) {
+	switch val.Kind() {
+	case reflect.Array:
+		b := make([]byte, val.Len())
+		reflect.Copy(reflect.ValueOf(b), val)
+		return b, nil
+	case reflect.Slice:
+		return val.Interface().([]byte), nil
+	default:
+		return nil, fmt.Errorf(jam.ErrUnsupportedType, val.Kind())
+	}
 }

--- a/pkg/serialization/codec/jam_codec_test.go
+++ b/pkg/serialization/codec/jam_codec_test.go
@@ -1,0 +1,106 @@
+package codec
+
+import (
+	"testing"
+
+	"github.com/eigerco/strawberry/pkg/serialization/codec/jam"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeErrors(t *testing.T) {
+	codec := &JAMCodec[uint64]{}
+
+	// Test with a non-pointer value
+	var nonPointer int
+	err := codec.Unmarshal([]byte{1}, nonPointer)
+	require.Error(t, err)
+	assert.Equal(t, jam.ErrNonPointerOrNil, err)
+
+	// Test with a nil pointer
+	var nilPointer *int
+	err = codec.Unmarshal([]byte{1}, nilPointer)
+	require.Error(t, err)
+	assert.Equal(t, jam.ErrNonPointerOrNil, err)
+
+	// Empty data
+	var dst *int
+	err = codec.Unmarshal([]byte{}, dst)
+	require.Error(t, err)
+	assert.Equal(t, jam.ErrEmptyData, err)
+}
+
+func TestEncodeDecodeSlice(t *testing.T) {
+	j := JAMCodec[uint64]{}
+
+	input := []byte{1, 2, 3, 4}
+	// Marshal the input value
+	serialized, err := j.Marshal(input)
+	require.NoError(t, err)
+
+	// Check if the serialized output matches the expected output
+	assert.Equal(t, []byte{4, 1, 2, 3, 4}, serialized, "serialized output mismatch for input %d", input)
+
+	// Unmarshal the serialized data back into byte
+	var deserialized []byte
+	err = j.Unmarshal(serialized, &deserialized)
+	require.NoError(t, err, "unmarshal(%v) returned an unexpected error", serialized)
+
+	// Check if the deserialized value matches the original input
+	assert.Equal(t, input, deserialized, "deserialized value mismatch for input %d", input)
+}
+
+func TestEncodeDecodeArray(t *testing.T) {
+	j := JAMCodec[uint32]{}
+
+	input := [4]byte{1, 2, 3, 4}
+	// Marshal the input value
+	serialized, err := j.Marshal(input)
+	require.NoError(t, err)
+
+	// Check if the serialized output matches the expected output
+	assert.Equal(t, []byte{4, 1, 2, 3, 4}, serialized, "serialized output mismatch for input %d", input)
+
+	// Unmarshal the serialized data back into byte
+	var deserialized [4]byte
+	err = j.Unmarshal(serialized, &deserialized)
+	require.NoError(t, err, "unmarshal(%v) returned an unexpected error", serialized)
+
+	// Check if the deserialized value matches the original input
+	assert.Equal(t, input, deserialized, "deserialized value mismatch for input %d", input)
+}
+
+func TestEncodeDecodeBool(t *testing.T) {
+	j := JAMCodec[uint32]{}
+
+	input := true
+	// Marshal the boolean value
+	serialized, err := j.Marshal(input)
+	require.NoError(t, err)
+
+	// Check if the serialized output matches the expected output
+	assert.Equal(t, []byte{1}, serialized, "serialized output mismatch for input %d", input)
+
+	// Unmarshal the serialized data back into bool
+	var deserialized bool
+	err = j.Unmarshal(serialized, &deserialized)
+	require.NoError(t, err, "unmarshal(%v) returned an unexpected error", serialized)
+
+	// Check if the deserialized value matches the original input
+	assert.Equal(t, input, deserialized, "deserialized value mismatch for input %d", input)
+
+	input = false
+	// Marshal the boolean value
+	serialized, err = j.Marshal(input)
+	require.NoError(t, err)
+
+	// Check if the serialized output matches the expected output
+	assert.Equal(t, []byte{0}, serialized, "serialized output mismatch for input %d", input)
+
+	// Unmarshal the serialized data back into bool
+	err = j.Unmarshal(serialized, &deserialized)
+	require.NoError(t, err, "unmarshal(%v) returned an unexpected error", serialized)
+
+	// Check if the deserialized value matches the original input
+	assert.Equal(t, input, deserialized, "deserialized value mismatch for input %d", input)
+}


### PR DESCRIPTION
This PR adds serialization logic for the following types:
- Adds length discriminator when encoding slices/array of bytes (C.1.4)
- Single boolean serialization (3.7.3)

Part of this: https://github.com/eigerco/strawberry/issues/6