### PR TITLE
Fix: Serialize length discriminator

### DIFF
--- a/pkg/serialization/codec/jam/errors.go
+++ b/pkg/serialization/codec/jam/errors.go
@@ -5,8 +5,7 @@ import (
 )
 
 var (
-	// errFirstByteNineByteSerialization is returned when the first byte has wrong value in 9-byte serialization
-	errFirstByteNineByteSerialization = errors.New("expected first byte to be 255 for 9-byte serialization")
+	errNotEnoughBytesToDeserializeNumber = errors.New("not enough bytes to deserialize the number")
 
 	ErrEmptyData       = errors.New("empty data")
 	ErrNonPointerOrNil = errors.New("value must be a not-nil pointer")

--- a/pkg/serialization/codec/jam/general_natural.go
+++ b/pkg/serialization/codec/jam/general_natural.go
@@ -42,10 +42,7 @@ func (j *GeneralNatural) DeserializeUint64(serialized []byte, u *uint64) error {
 		return nil
 	}
 
-	if n > 8 {
-		if serialized[0] != math.MaxUint8 {
-			return errFirstByteNineByteSerialization
-		}
+	if serialized[0] == math.MaxUint8 && n > 8 {
 		*u = binary.LittleEndian.Uint64(serialized[1:9])
 		return nil
 	}
@@ -53,6 +50,9 @@ func (j *GeneralNatural) DeserializeUint64(serialized []byte, u *uint64) error {
 	prefix := serialized[0]
 	l := uint8(bits.LeadingZeros8(^prefix))
 
+	if int(l) > n-1 {
+		return errNotEnoughBytesToDeserializeNumber
+	}
 	// Deserialize the first `l` bytes
 	for i := uint8(0); i < l; i++ {
 		*u |= uint64(serialized[i+1]) << (8 * i)


### PR DESCRIPTION
This PR adds a fix to serialize/deserialize length discriminator with natural number encoding (274)

Part of this: https://github.com/eigerco/strawberry/issues/6