### PR TITLE
Add bandersnatch methods

### DIFF
--- a/internal/crypto/bandersnatch/bandersnatch.go
+++ b/internal/crypto/bandersnatch/bandersnatch.go
@@ -1,0 +1,89 @@
+package bandersnatch
+
+import (
+	"errors"
+	"github.com/eigerco/strawberry/internal/crypto"
+)
+
+// PrivateKey represents a Bandersnatch private key.
+type PrivateKey struct {
+	seed      crypto.BandersnatchSeedKey   // Seed used to derive the private key
+	secretKey crypto.BandersnatchSecretKey // The actual secret value
+}
+
+// VrfSignData represents the data needed for VRF signing
+// nolint: unused
+type VrfSignData struct {
+	transcript []byte   // ⟨x ∈ Y⟩ Contextual data that influences the signature
+	inputs     [][]byte // (m) Input data elements to be signed, can vary in size
+}
+
+// NewPrivateKeyFromSeed creates a new private key from a seed
+func NewPrivateKeyFromSeed(seed crypto.BandersnatchSeedKey) (*PrivateKey, error) {
+	// FFI call to Rust code would populate secretKey
+	return &PrivateKey{seed: seed, secretKey: crypto.BandersnatchSecretKey{}}, nil
+}
+
+// Public returns the public key associated with the private key
+func (pk *PrivateKey) Public() crypto.BandersnatchPublicKey {
+	// FFI call to Rust code would populate publicKey based on pk.secretKey
+	return crypto.BandersnatchPublicKey{}
+}
+
+// Sign creates a Schnorr signature for the given data using the private key
+func (pk *PrivateKey) Sign(data []byte) (crypto.BandersnatchSignature, error) {
+	if len(data) == 0 {
+		return crypto.BandersnatchSignature{}, errors.New("data to sign cannot be empty")
+	}
+	// FFI call to Rust code would populate signature
+	return crypto.BandersnatchSignature{}, nil
+}
+
+// GenerateVrfProof generates a VRF proof for the given data and context using the private key
+func (pk *PrivateKey) GenerateVrfProof(data, context []byte) (crypto.VrfProof, error) {
+	// FFI call to Rust code would populate proof
+	return crypto.VrfProof{}, nil
+}
+
+// VerifySignature verifies a bandersnatch signature against the given data and public key
+func VerifySignature(signature crypto.BandersnatchSignature, data []byte, pubKey crypto.BandersnatchPublicKey) bool {
+	// FFI call to Rust code to verify the signature
+	return true
+}
+
+// VerifyVrfProof verifies a VRF proof against the given data, context, and public key
+func VerifyVrfProof(proof crypto.VrfProof, data, context []byte, pubKey crypto.BandersnatchPublicKey) bool {
+	// FFI call to Rust code to verify the VRF proof
+	return true
+}
+
+// RingVrfSign signs the data using ring VRF
+func (pk *PrivateKey) RingVrfSign(data VrfSignData) (crypto.RingVrfSignature, error) {
+	// FFI call to Rust code would populate signature using ring VRF logic
+	return crypto.RingVrfSignature{}, nil
+}
+
+// RingVrfVerify verifies a ring VRF signature against the given data
+func RingVrfVerify(signature crypto.RingVrfSignature, data VrfSignData) bool {
+	// FFI call to Rust code to verify the ring VRF signature
+	return true
+}
+
+// VerifyProof verifies a zero-knowledge proof for the provided VRF data
+func VerifyProof(proof crypto.VrfProof, data VrfSignData) bool {
+	// FFI call to Rust code to verify the proof
+	// This verification checks if the proof shows valid knowledge of a secret as per the zk-SNARK setup
+	return true
+}
+
+// GenerateVrfOutput derives the high-entropy hash output from a VRF proof
+func GenerateVrfOutput(proof crypto.VrfProof) (crypto.VrfOutput, error) {
+	// FFI call to Rust code to derive the VRF output from the proof
+	return crypto.VrfOutput{}, nil
+}
+
+// GenerateRingCommitment generates a KZG commitment for a set of public keys.
+func GenerateRingCommitment(pubKeys []crypto.BandersnatchPublicKey) (crypto.RingCommitment, error) {
+	// FFI call to Rust code to generate the KZG commitment
+	return crypto.RingCommitment{}, nil
+}

--- a/internal/crypto/keys.go
+++ b/internal/crypto/keys.go
@@ -10,8 +10,13 @@ type Ed25519PublicKey struct{
 }
 type Ed25519PrivateKey ed25519.PrivateKey
 type BlsKey [BLSSize]byte
+type BandersnatchSeedKey [BandersnatchSize]byte
+type BandersnatchSecretKey [BandersnatchSize]byte
 type BandersnatchPublicKey [BandersnatchSize]byte
 type BandersnatchSignature [96]byte
+type VrfProof [784]byte
+type VrfOutput [32]byte
+type RingVrfSignature [784]byte
 type MetadataKey [MetadataSize]byte
 type RingCommitment [BandersnatchRingSize]byte
 type EpochKeys [jamtime.TimeslotsPerEpoch]BandersnatchPublicKey


### PR DESCRIPTION
In this PR I just add the methods and types we might need based on the GP (3.8 & Apendix G). In the following PRs I will add the implementation (through FFI).