### PR TITLE
Fix types and ordering of fields for block deserialization

### DIFF
--- a/internal/block/assurance.go
+++ b/internal/block/assurance.go
@@ -11,10 +11,10 @@ import "github.com/eigerco/strawberry/internal/crypto"
 // - A signature validating the assurance
 // Assurances must be ordered by validator index in the extrinsic.
 type Assurance struct {
-	Anchor         crypto.Hash                       // Parent block hash (a ∈ H)
-	Flag           bool                              // Bitstring of assurances, one bit per core (f ∈ B_C)
-	ValidatorIndex uint16                            // Index of the attesting validator (v ∈ N_V)
-	Signature      [crypto.Ed25519SignatureSize]byte // Ed25519 signature (s ∈ E)
+	Anchor         crypto.Hash             // Parent block hash (a ∈ H)
+	Flag           bool                    // Bitstring of assurances, one bit per core (f ∈ B_C)
+	ValidatorIndex uint16                  // Index of the attesting validator (v ∈ N_V)
+	Signature      crypto.Ed25519Signature // Ed25519 signature (s ∈ E)
 }
 
 type AssurancesExtrinsic []Assurance

--- a/internal/block/block.go
+++ b/internal/block/block.go
@@ -9,8 +9,8 @@ type Block struct {
 // Extrinsic represents the block extrinsic data
 type Extrinsic struct {
 	ET TicketExtrinsic
-	EP PreimageExtrinsic
 	ED DisputeExtrinsic
+	EP PreimageExtrinsic
 	EA AssurancesExtrinsic
 	EG GuaranteesExtrinsic
 }

--- a/internal/block/block_test.go
+++ b/internal/block/block_test.go
@@ -26,7 +26,7 @@ func Test_BlockEncodeDecode(t *testing.T) {
 			},
 			Entropy: testutils.RandomHash(t),
 		},
-		WinningTicketsMarker: [jamtime.TimeslotsPerEpoch]*Ticket{{
+		WinningTicketsMarker: &[jamtime.TimeslotsPerEpoch]Ticket{{
 			Identifier: testutils.RandomHash(t),
 			EntryIndex: 112,
 		},
@@ -133,7 +133,7 @@ func Test_BlockEncodeDecode(t *testing.T) {
 				},
 				Credentials: []CredentialSignature{
 					{
-						ValidatorIndex: uint32(1),
+						ValidatorIndex: uint16(1),
 						Signature:      testutils.RandomEd25519Signature(t),
 					},
 				},

--- a/internal/block/dispute.go
+++ b/internal/block/dispute.go
@@ -19,21 +19,21 @@ type Verdict struct {
 }
 
 type Culprit struct {
-	ReportHash                crypto.Hash                       // H, hash of the work report
-	ValidatorEd25519PublicKey crypto.Ed25519PublicKey           // He
-	Signature                 [crypto.Ed25519SignatureSize]byte // E
+	ReportHash                crypto.Hash             // H, hash of the work report
+	ValidatorEd25519PublicKey crypto.Ed25519PublicKey // He
+	Signature                 crypto.Ed25519Signature // E
 }
 
 type Fault struct {
-	ReportHash                crypto.Hash                       // H, hash of the work report
-	IsValid                   bool                              // {⊺,⊥}
-	ValidatorEd25519PublicKey crypto.Ed25519PublicKey           // He
-	Signature                 [crypto.Ed25519SignatureSize]byte // E
+	ReportHash                crypto.Hash             // H, hash of the work report
+	IsValid                   bool                    // {⊺,⊥}
+	ValidatorEd25519PublicKey crypto.Ed25519PublicKey // He
+	Signature                 crypto.Ed25519Signature // E
 }
 
 // Judgment represents a single judgment with a signature
 type Judgment struct {
-	IsValid        bool                              // v: {⊺,⊥}
-	ValidatorIndex uint16                            // i: NV
-	Signature      [crypto.Ed25519SignatureSize]byte // s: E
+	IsValid        bool                    // v: {⊺,⊥}
+	ValidatorIndex uint16                  // i: NV
+	Signature      crypto.Ed25519Signature // s: E
 }

--- a/internal/block/guarantee.go
+++ b/internal/block/guarantee.go
@@ -13,13 +13,13 @@ type GuaranteesExtrinsic struct {
 // Guarantee represents a single guarantee within the E_G extrinsic
 type Guarantee struct {
 	WorkReport  WorkReport            // The work report being guaranteed
-	Credentials []CredentialSignature // The credentials proving the guarantee's validity
 	Timeslot    jamtime.Timeslot      // The timeslot when this guarantee was made
+	Credentials []CredentialSignature // The credentials proving the guarantee's validity
 }
 
 // CredentialSignature represents a single signature within the credential
 type CredentialSignature struct {
-	ValidatorIndex uint32                            // Index of the validator providing this signature
+	ValidatorIndex uint16                            // Index of the validator providing this signature
 	Signature      [crypto.Ed25519SignatureSize]byte // The Ed25519 signature
 }
 

--- a/internal/block/header.go
+++ b/internal/block/header.go
@@ -14,7 +14,7 @@ type Header struct {
 	ExtrinsicHash        crypto.Hash                        // Hx
 	TimeSlotIndex        jamtime.Timeslot                   // Ht
 	EpochMarker          *EpochMarker                       // He
-	WinningTicketsMarker [jamtime.TimeslotsPerEpoch]*Ticket // Hw
+	WinningTicketsMarker *[jamtime.TimeslotsPerEpoch]Ticket // Hw
 	OffendersMarkers     []crypto.Ed25519PublicKey          // Ho, the culprit's and fault's public keys
 	BlockAuthorIndex     uint16                             // Hi
 	VRFSignature         crypto.BandersnatchSignature       // Hv
@@ -24,6 +24,6 @@ type Header struct {
 // EpochMarker consists of epoch randomness and a sequence of
 // Bandersnatch keys defining the Bandersnatch validator keys (kb) beginning in the next epoch.
 type EpochMarker struct {
-	Keys    [NumberOfValidators]crypto.BandersnatchPublicKey
 	Entropy crypto.Hash
+	Keys    [NumberOfValidators]crypto.BandersnatchPublicKey
 }

--- a/internal/block/header_test.go
+++ b/internal/block/header_test.go
@@ -27,7 +27,7 @@ func Test_HeaderEncodeDecode(t *testing.T) {
 			},
 			Entropy: testutils.RandomHash(t),
 		},
-		WinningTicketsMarker: [jamtime.TimeslotsPerEpoch]*Ticket{{
+		WinningTicketsMarker: &[jamtime.TimeslotsPerEpoch]Ticket{{
 			Identifier: testutils.RandomHash(t),
 			EntryIndex: 111,
 		}, {

--- a/internal/crypto/keys.go
+++ b/internal/crypto/keys.go
@@ -9,6 +9,7 @@ type Ed25519PublicKey struct {
 	ed25519.PublicKey
 }
 type Ed25519PrivateKey ed25519.PrivateKey
+type Ed25519Signature [Ed25519SignatureSize]byte
 type BlsKey [BLSSize]byte
 type BandersnatchSeedKey [BandersnatchSize]byte
 type BandersnatchSecretKey [BandersnatchSize]byte


### PR DESCRIPTION
Small changes in order to support test vector block decoding