### PR TITLE
Add RingVRF Go API

### DIFF
--- a/internal/crypto/bandersnatch/bandersnatch_test.go
+++ b/internal/crypto/bandersnatch/bandersnatch_test.go
@@ -1,27 +1,33 @@
 package bandersnatch
 
 import (
+	"encoding/binary"
 	"testing"
 
+	"github.com/eigerco/strawberry/internal/common"
 	"github.com/eigerco/strawberry/internal/crypto"
 	"github.com/stretchr/testify/require"
 )
 
-var seed = crypto.BandersnatchSeedKey{
-	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
-	0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
-	0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
-	0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20,
+// Creates a seed from an uint.
+func uintToSeed(i uint) (seed crypto.BandersnatchSeedKey) {
+	binary.LittleEndian.PutUint32(seed[:], uint32(i))
+	return seed
+}
+
+func TestInitRingSize(t *testing.T) {
+	// Confirm that the ring size is being correctly intialized within the init() fn.
+	require.Equal(t, uint(common.NumberOfValidators), GetRingSize())
 }
 
 func TestSignAndVerify(t *testing.T) {
-	sk, err := NewPrivateKeyFromSeed(seed)
+	sk, err := NewPrivateKeyFromSeed(uintToSeed(1))
 	require.NoError(t, err)
 	pk, err := Public(sk)
 	require.NoError(t, err)
 
-	vrfInputData := []byte("vrf data")
-	auxData := []byte("aux data")
+	vrfInputData := []byte("foo")
+	auxData := []byte("bar")
 	sig, err := Sign(sk, vrfInputData, auxData)
 	require.NoError(t, err)
 
@@ -31,4 +37,61 @@ func TestSignAndVerify(t *testing.T) {
 	outputHash2, err := OutputHash(sig)
 	require.NoError(t, err)
 	require.Equal(t, outputHash, outputHash2)
+}
+
+func TestRingSignAndVerify(t *testing.T) {
+	// Setup a ring using the index in the loop as a seed.
+	ring := []crypto.BandersnatchPublicKey{}
+	for i := uint(0); i < GetRingSize(); i++ {
+		seed := uintToSeed(i)
+
+		sk, err := NewPrivateKeyFromSeed(seed)
+		require.NoError(t, err)
+
+		pk, err := Public(sk)
+		require.NoError(t, err)
+
+		ring = append(ring, pk)
+	}
+
+	var proverIdx uint = 3
+	proverSk, err := NewPrivateKeyFromSeed(uintToSeed(proverIdx))
+	require.NoError(t, err)
+	proverPk := ring[proverIdx]
+
+	prover, err := NewRingProver(proverSk, ring, proverIdx)
+	require.NoError(t, err)
+	defer prover.Free()
+
+	verifier, err := NewRingVerifier(ring)
+	require.NoError(t, err)
+	defer verifier.Free()
+
+	commitment, err := verifier.Commitment()
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	vrfInputData := []byte("foo")
+	auxData := []byte("bar")
+
+	ringSignature, err := prover.Sign(vrfInputData, auxData)
+	require.NoError(t, err)
+
+	ok, ringOutputHash := verifier.Verify(vrfInputData, auxData, commitment, ringSignature)
+	require.True(t, ok)
+
+	// Sign the same vrf input data using the regular bandersnatch signature,
+	// with different aux data.
+	differentAuxData := []byte("baz")
+
+	signature, err := Sign(proverSk, vrfInputData, differentAuxData)
+	require.NoError(t, err)
+
+	ok, outputHash := Verify(proverPk, vrfInputData, differentAuxData, signature)
+	require.True(t, ok)
+
+	// Should still have the same output hash, since both signatures used the
+	// same vrf input data.
+	require.Equal(t, ringOutputHash, outputHash)
 }

--- a/internal/crypto/keys.go
+++ b/internal/crypto/keys.go
@@ -11,10 +11,6 @@ type BlsKey [BLSSize]byte
 type BandersnatchSeedKey [BandersnatchSize]byte
 type BandersnatchPrivateKey [BandersnatchSize]byte
 type BandersnatchPublicKey [BandersnatchSize]byte
-
-// TODO this is a tmp variable to hold the value of 33 bytes key that polkadot-sdk uses
-// We should remove this after we fix the bandersnatch implementation
-type BandersnatchSerializedPublicKey [BandersnatchSerializedSize]byte
 type BandersnatchSignature [96]byte
 type BandersnatchOutputHash [32]byte
 type RingVrfSignature [VrfProofSize]byte


### PR DESCRIPTION
- Add a Go API for RingVRF signing, verifying, and generating an output hash.
- Add the ability to initialize the ring size. This is needed since the ring size influences the KZG commitment. Test vectors use a ring size of 6, while the production value is 1023.

Part 2 of https://github.com/eigerco/strawberry/issues/87