### PR TITLE
Update PVM host functions to 0.5.0

### DIFF
--- a/internal/polkavm/host_call/common.go
+++ b/internal/polkavm/host_call/common.go
@@ -13,7 +13,7 @@ const (
 	ReadCost
 	WriteCost
 	InfoCost
-	EmpowerCost
+	BlessCost
 	AssignCost
 	DesignateCost
 	CheckpointCost
@@ -31,7 +31,7 @@ const (
 	ReadID       = 2
 	WriteID      = 3
 	InfoID       = 4
-	EmpowerID    = 5
+	BlessID      = 5
 	AssignID     = 6
 	DesignateID  = 7
 	CheckpointID = 8
@@ -93,7 +93,7 @@ func readNumber[U interface{ ~uint32 | ~uint64 }](mem Memory, addr uint32, lengt
 		return
 	}
 
-	jam.DeserializeTrivialNatural(b, &u)
+	err = jam.Unmarshal(b, &u)
 	return
 }
 

--- a/internal/polkavm/host_call/general_functions_test.go
+++ b/internal/polkavm/host_call/general_functions_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/blake2b"
 
 	"github.com/eigerco/strawberry/internal/block"
 	"github.com/eigerco/strawberry/internal/crypto"
@@ -31,7 +30,6 @@ func TestGasRemaining(t *testing.T) {
 
 	initialRegs := polkavm.Registers{
 		polkavm.RA: polkavm.VmAddressReturnToHost,
-		polkavm.SP: memoryMap.StackAddressHigh,
 	}
 	initialGas := uint64(100)
 	hostCall := func(hostCall uint32, gasCounter polkavm.Gas, regs polkavm.Registers, mem polkavm.Memory, x struct{}) (polkavm.Gas, polkavm.Registers, polkavm.Memory, struct{}, error) {
@@ -92,7 +90,7 @@ func TestLookup(t *testing.T) {
 		bo := memoryMap.RWDataAddress + 100
 		dataToHash := make([]byte, 32)
 		copy(dataToHash, "hash")
-		hash := blake2b.Sum256(dataToHash)
+		hash := crypto.HashData(dataToHash)
 		err := mem.Write(ho, dataToHash)
 		require.NoError(t, err)
 
@@ -153,7 +151,7 @@ func TestRead(t *testing.T) {
 	hashInput := make([]byte, 0, len(serviceIdBytes)+len(keyData))
 	hashInput = append(hashInput, serviceIdBytes...)
 	hashInput = append(hashInput, keyData...)
-	k := blake2b.Sum256(hashInput)
+	k := crypto.HashData(hashInput)
 
 	sa := service.ServiceAccount{
 		Storage: map[crypto.Hash][]byte{
@@ -221,7 +219,7 @@ func TestWrite(t *testing.T) {
 	require.NoError(t, err)
 
 	hashInput := append(serviceIdBytes, keyData...)
-	k := blake2b.Sum256(hashInput)
+	k := crypto.HashData(hashInput)
 
 	sa := service.ServiceAccount{
 		Balance: 200,

--- a/internal/statetransition/on_transfer.go
+++ b/internal/statetransition/on_transfer.go
@@ -1,13 +1,14 @@
 package statetransition
 
 import (
+	"log"
+
 	"github.com/eigerco/strawberry/internal/block"
 	"github.com/eigerco/strawberry/internal/polkavm"
 	"github.com/eigerco/strawberry/internal/polkavm/host_call"
 	"github.com/eigerco/strawberry/internal/polkavm/interpreter"
 	"github.com/eigerco/strawberry/internal/service"
 	"github.com/eigerco/strawberry/pkg/serialization/codec/jam"
-	"log"
 )
 
 // InvokePVMOnTransfer On-Transfer service-account invocation (ΨT).
@@ -48,7 +49,7 @@ func InvokePVMOnTransfer(serviceState service.ServiceState, serviceIndex block.S
 		return gasCounter, regs, mem, serviceAccount, err
 	}
 
-	_, _, newServiceAccount, err := interpreter.InvokeWholeProgram(serviceCode, 15, gas, args, hostCallFunc, serviceAccount)
+	_, _, newServiceAccount, err := interpreter.InvokeWholeProgram(serviceCode, 10, gas, args, hostCallFunc, serviceAccount)
 	if err != nil {
 		// TODO handle errors appropriately
 		log.Println("the virtual machine exited with an error", err)

--- a/pkg/serialization/codec/jam/decode.go
+++ b/pkg/serialization/codec/jam/decode.go
@@ -341,7 +341,7 @@ func (br *byteReader) decodeUint(value reflect.Value) error {
 	}
 
 	var v uint64
-	err = DeserializeUint64WithLength(serialized, l, &v)
+	err = deserializeUint64WithLength(serialized, l, &v)
 	if err != nil {
 		return fmt.Errorf(ErrDecodingUint, err)
 	}
@@ -419,19 +419,19 @@ func (br *byteReader) decodeFixedWidthInt(dstv reflect.Value) error {
 	switch in.(type) {
 	case uint8:
 		var temp uint8
-		DeserializeTrivialNatural(buf, &temp)
+		deserializeTrivialNatural(buf, &temp)
 		dstv.Set(reflect.ValueOf(temp))
 	case uint16:
 		var temp uint16
-		DeserializeTrivialNatural(buf, &temp)
+		deserializeTrivialNatural(buf, &temp)
 		dstv.Set(reflect.ValueOf(temp))
 	case uint32:
 		var temp uint32
-		DeserializeTrivialNatural(buf, &temp)
+		deserializeTrivialNatural(buf, &temp)
 		dstv.Set(reflect.ValueOf(temp))
 	case uint64:
 		var temp uint64
-		DeserializeTrivialNatural(buf, &temp)
+		deserializeTrivialNatural(buf, &temp)
 		dstv.Set(reflect.ValueOf(temp))
 	}
 

--- a/pkg/serialization/codec/jam/encode.go
+++ b/pkg/serialization/codec/jam/encode.go
@@ -292,13 +292,13 @@ func (bw *byteWriter) encodeFixedWidthUint(i interface{}) error {
 
 	switch v := i.(type) {
 	case uint8:
-		data = SerializeTrivialNatural(v, 1)
+		data = serializeTrivialNatural(v, 1)
 	case uint16:
-		data = SerializeTrivialNatural(v, 2)
+		data = serializeTrivialNatural(v, 2)
 	case uint32:
-		data = SerializeTrivialNatural(v, 4)
+		data = serializeTrivialNatural(v, 4)
 	case uint64:
-		data = SerializeTrivialNatural(v, 8)
+		data = serializeTrivialNatural(v, 8)
 	default:
 		return fmt.Errorf(ErrUnsupportedType, i)
 	}
@@ -341,7 +341,7 @@ func (bw *byteWriter) encodeLength(l int) error {
 }
 
 func (bw *byteWriter) encodeUint(i uint) error {
-	encodedBytes := SerializeUint64(uint64(i))
+	encodedBytes := serializeUint64(uint64(i))
 
 	_, err := bw.Write(encodedBytes)
 

--- a/pkg/serialization/codec/jam/general_natural.go
+++ b/pkg/serialization/codec/jam/general_natural.go
@@ -5,8 +5,8 @@ import (
 	"math"
 )
 
-// SerializeUint64 implements the general formula (able to encode naturals of up to 2^64)
-func SerializeUint64(x uint64) []byte {
+// serializeUint64 implements the general formula (able to encode naturals of up to 2^64)
+func serializeUint64(x uint64) []byte {
 	var l uint8
 	// Determine the length needed to represent the value
 	for l = 0; l < 8; l++ {
@@ -30,8 +30,8 @@ func SerializeUint64(x uint64) []byte {
 	return bytes
 }
 
-// DeserializeUint64WithLength deserializes a byte slice into a uint64 value, with length `l`.
-func DeserializeUint64WithLength(serialized []byte, l uint8, u *uint64) error {
+// deserializeUint64WithLength deserializes a byte slice into a uint64 value, with length `l`.
+func deserializeUint64WithLength(serialized []byte, l uint8, u *uint64) error {
 	*u = 0
 
 	n := len(serialized)

--- a/pkg/serialization/codec/jam/general_natural_test.go
+++ b/pkg/serialization/codec/jam/general_natural_test.go
@@ -2,11 +2,12 @@ package jam
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"math"
 	"math/bits"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEncodeDecodeUint64(t *testing.T) {
@@ -53,7 +54,7 @@ func TestEncodeDecodeUint64(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("uint64(%d)", tc.input), func(t *testing.T) {
 			// Marshal the x value
-			serialized := SerializeUint64(tc.input)
+			serialized := serializeUint64(tc.input)
 
 			// Check if the serialized output matches the expected output
 			assert.Equal(t, tc.expected, serialized, "serialized output mismatch for x %d", tc.input)
@@ -64,7 +65,7 @@ func TestEncodeDecodeUint64(t *testing.T) {
 			}
 			// Unmarshal the serialized data back into a uint64
 			var deserialized uint64
-			err := DeserializeUint64WithLength(serialized, l, &deserialized)
+			err := deserializeUint64WithLength(serialized, l, &deserialized)
 			require.NoError(t, err, "unmarshal(%v) returned an unexpected error", serialized)
 
 			// Check if the deserialized value matches the original x

--- a/pkg/serialization/codec/jam/trivial_natural.go
+++ b/pkg/serialization/codec/jam/trivial_natural.go
@@ -4,7 +4,7 @@ import (
 	"math"
 )
 
-func SerializeTrivialNatural[T ~uint8 | ~uint16 | ~uint32 | ~uint64](x T, l uint8) []byte {
+func serializeTrivialNatural[T ~uint8 | ~uint16 | ~uint32 | ~uint64](x T, l uint8) []byte {
 	bytes := make([]byte, l)
 	for i := uint8(0); i < l; i++ {
 		bytes[i] = byte((x >> (8 * i)) & T(math.MaxUint8))
@@ -12,7 +12,7 @@ func SerializeTrivialNatural[T ~uint8 | ~uint16 | ~uint32 | ~uint64](x T, l uint
 	return bytes
 }
 
-func DeserializeTrivialNatural[T ~uint8 | ~uint16 | ~uint32 | ~uint64](serialized []byte, u *T) {
+func deserializeTrivialNatural[T ~uint8 | ~uint16 | ~uint32 | ~uint64](serialized []byte, u *T) {
 	*u = 0
 
 	// Iterate over each byte in the serialized array

--- a/pkg/serialization/codec/jam/trivial_natural_test.go
+++ b/pkg/serialization/codec/jam/trivial_natural_test.go
@@ -49,13 +49,13 @@ func TestSerializationTrivialNatural(t *testing.T) {
 			var serialized []byte
 			switch v := tc.x.(type) {
 			case uint8:
-				serialized = SerializeTrivialNatural(v, tc.l)
+				serialized = serializeTrivialNatural(v, tc.l)
 			case uint16:
-				serialized = SerializeTrivialNatural(v, tc.l)
+				serialized = serializeTrivialNatural(v, tc.l)
 			case uint32:
-				serialized = SerializeTrivialNatural(v, tc.l)
+				serialized = serializeTrivialNatural(v, tc.l)
 			case uint64:
-				serialized = SerializeTrivialNatural(v, tc.l)
+				serialized = serializeTrivialNatural(v, tc.l)
 			}
 
 			assert.Equal(t, tc.expected, serialized, "serialized output mismatch")
@@ -63,19 +63,19 @@ func TestSerializationTrivialNatural(t *testing.T) {
 			switch v := tc.x.(type) {
 			case uint8:
 				var deserialized uint8
-				DeserializeTrivialNatural(serialized, &deserialized)
+				deserializeTrivialNatural(serialized, &deserialized)
 				assert.Equal(t, v, deserialized, "deserialized value mismatch")
 			case uint16:
 				var deserialized uint16
-				DeserializeTrivialNatural(serialized, &deserialized)
+				deserializeTrivialNatural(serialized, &deserialized)
 				assert.Equal(t, v, deserialized, "deserialized value mismatch")
 			case uint32:
 				var deserialized uint32
-				DeserializeTrivialNatural(serialized, &deserialized)
+				deserializeTrivialNatural(serialized, &deserialized)
 				assert.Equal(t, v, deserialized, "deserialized value mismatch")
 			case uint64:
 				var deserialized uint64
-				DeserializeTrivialNatural(serialized, &deserialized)
+				deserializeTrivialNatural(serialized, &deserialized)
 				assert.Equal(t, v, deserialized, "deserialized value mismatch")
 			}
 		})


### PR DESCRIPTION
I updated the accumulate and general host functions to align with the 0.5.0 changes. The transition of registers and host result codes to `uint64` will be addressed in a separate PR.