### PR TITLE
Add recent history integration test

### DIFF
--- a/internal/merkle/mountain_ranges/mmr.go
+++ b/internal/merkle/mountain_ranges/mmr.go
@@ -13,8 +13,7 @@ func New() *MMR {
 
 // Append (A function): A(r, l, H) ↦ P(r, l, 0, H) from equation (327)
 func (m *MMR) Append(r []*crypto.Hash, l crypto.Hash, hashFunc func([]byte) crypto.Hash) []*crypto.Hash {
-	hash := hashFunc(l[:])
-	return placePeak(r, &hash, 0, hashFunc)
+	return placePeak(r, &l, 0, hashFunc)
 }
 
 // placePeak implements P function from equation (327):

--- a/tests/integration/recent_history_integration_test.go
+++ b/tests/integration/recent_history_integration_test.go
@@ -1,0 +1,124 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eigerco/strawberry/internal/crypto"
+	"github.com/eigerco/strawberry/internal/state"
+	"github.com/eigerco/strawberry/internal/statetransition"
+	"github.com/eigerco/strawberry/internal/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecentHistory(t *testing.T) {
+	testFiles := []string{
+		// Empty hjstory queue.
+		"vectors/recenthistory/progress_blocks_history-1.json",
+
+		// Not empty nor full history queue.
+		"vectors/recenthistory/progress_blocks_history-2.json",
+
+		// Fill the history queue.
+		"vectors/recenthistory/progress_blocks_history-3.json",
+
+		// Shift the history queue.
+		"vectors/recenthistory/progress_blocks_history-4.json",
+	}
+
+	for _, tf := range testFiles {
+		t.Run(filepath.Base(tf), func(t *testing.T) {
+			file, err := os.ReadFile(tf)
+			require.NoError(t, err)
+
+			var tv RecentHistoryTestVector
+			err = json.Unmarshal(file, &tv)
+			require.NoError(t, err)
+
+			// Inputs.
+			headerHash := crypto.Hash(testutils.MustFromHex(t, tv.Input.HeaderHash))
+			parentStateRoot := crypto.Hash(testutils.MustFromHex(t, tv.Input.ParentStateRoot))
+			accumulateRoot := crypto.Hash(testutils.MustFromHex(t, tv.Input.AccumulateRoot))
+
+			preRecentBlocks := toRecentBlocks(t, tv.PreState)
+
+			workPackages := map[crypto.Hash]crypto.Hash{}
+			for _, wp := range tv.Input.WorkPackages {
+				hash := crypto.Hash(testutils.MustFromHex(t, wp.Hash))
+				exportsRoot := crypto.Hash(testutils.MustFromHex(t, wp.ExportsRoot))
+
+				workPackages[hash] = exportsRoot
+			}
+
+			newRecentBlocks, err := statetransition.UpdateRecentBlocks(headerHash, parentStateRoot, accumulateRoot, preRecentBlocks, workPackages)
+			require.NoError(t, err)
+
+			postRecentBlocks := toRecentBlocks(t, tv.PostState)
+			require.Equal(t, postRecentBlocks, newRecentBlocks)
+		})
+
+	}
+}
+
+func toRecentBlocks(t *testing.T, s RecentHistoryTestVectorState) []state.BlockState {
+	intermediateBlocks := make([]state.BlockState, len(s.Beta))
+	for i, bs := range s.Beta {
+		accResultMMR := make([]*crypto.Hash, len(bs.MMR.Peaks))
+		for i, p := range bs.MMR.Peaks {
+			if p != nil {
+				peak := crypto.Hash(testutils.MustFromHex(t, *p))
+				accResultMMR[i] = &peak
+			}
+		}
+
+		workReportHashes := map[crypto.Hash]crypto.Hash{}
+		for _, wr := range bs.Reported {
+			hash := crypto.Hash(testutils.MustFromHex(t, wr.Hash))
+			exportsRoot := crypto.Hash(testutils.MustFromHex(t, wr.ExportsRoot))
+
+			workReportHashes[hash] = exportsRoot
+		}
+
+		intermediateBlocks[i] = state.BlockState{
+			HeaderHash:            crypto.Hash(testutils.MustFromHex(t, bs.HeaderHash)),
+			StateRoot:             crypto.Hash(testutils.MustFromHex(t, bs.StateRoot)),
+			AccumulationResultMMR: accResultMMR,
+			WorkReportHashes:      workReportHashes,
+		}
+	}
+
+	return intermediateBlocks
+}
+
+type RecentHistoryTestVector struct {
+	Input struct {
+		HeaderHash      string `json:"header_hash"`
+		ParentStateRoot string `json:"parent_state_root"`
+		AccumulateRoot  string `json:"accumulate_root"`
+		WorkPackages    []struct {
+			Hash        string `json:"hash"`
+			ExportsRoot string `json:"exports_root"`
+		} `json:"work_packages"`
+	} `json:"input"`
+	PreState  RecentHistoryTestVectorState `json:"pre_state"`
+	Output    interface{}                  `json:"output"`
+	PostState RecentHistoryTestVectorState `json:"post_state"`
+}
+
+type RecentHistoryTestVectorState struct {
+	Beta []struct {
+		HeaderHash string `json:"header_hash"`
+		MMR        struct {
+			Peaks []*string `json:"peaks"`
+		} `json:"mmr"`
+		StateRoot string `json:"state_root"`
+		Reported  []struct {
+			Hash        string `json:"hash"`
+			ExportsRoot string `json:"exports_root"`
+		} `json:"reported"`
+	} `json:"beta"`
+}

--- a/tests/integration/vectors/recenthistory/progress_blocks_history-1.json
+++ b/tests/integration/vectors/recenthistory/progress_blocks_history-1.json
@@ -1,0 +1,44 @@
+{
+    "input": {
+        "header_hash": "0x530ef4636fedd498e99c7601581271894a53e965e901e8fa49581e525f165dae",
+        "parent_state_root": "0x0e6c6cbf80b5fb00175001f7b0966bf1af83ff4406ede84f29a666a0fcbac801",
+        "accumulate_root": "0x8720b97ddd6acc0f6eb66e095524038675a4e4067adc10ec39939eaefc47d842",
+        "work_packages": [
+            {
+                "hash": "0x016cb55eb7b84e0d495d40832c7238965baeb468932c415dc2ceffe0afb039e5",
+                "exports_root": "0x935f6dfef36fa06e10a9ba820f933611c05c06a207b07141fe8d87465870c11c"
+            },
+            {
+                "hash": "0x76bcb24901299c331f0ca7342f4874f19b213ee72df613d50699e7e25edb82a6",
+                "exports_root": "0xc825d16b7325ca90287123bd149d47843c999ce686ed51eaf8592dd2759272e3"
+            }
+        ]
+    },
+    "pre_state": {
+        "beta": []
+    },
+    "output": null,
+    "post_state": {
+        "beta": [
+            {
+                "header_hash": "0x530ef4636fedd498e99c7601581271894a53e965e901e8fa49581e525f165dae",
+                "mmr": {
+                    "peaks": [
+                        "0x8720b97ddd6acc0f6eb66e095524038675a4e4067adc10ec39939eaefc47d842"
+                    ]
+                },
+                "state_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "reported": [
+                    {
+                        "hash": "0x016cb55eb7b84e0d495d40832c7238965baeb468932c415dc2ceffe0afb039e5",
+                        "exports_root": "0x935f6dfef36fa06e10a9ba820f933611c05c06a207b07141fe8d87465870c11c"
+                    },
+                    {
+                        "hash": "0x76bcb24901299c331f0ca7342f4874f19b213ee72df613d50699e7e25edb82a6",
+                        "exports_root": "0xc825d16b7325ca90287123bd149d47843c999ce686ed51eaf8592dd2759272e3"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/integration/vectors/recenthistory/progress_blocks_history-2.json
+++ b/tests/integration/vectors/recenthistory/progress_blocks_history-2.json
@@ -1,0 +1,76 @@
+{
+    "input": {
+        "header_hash": "0x241d129c6edc2114e6dfba7d556f7f7c66399b55ceec3078a53d44c752ba7e9a",
+        "parent_state_root": "0x1831dde64e40bfd8639c2d122e5ac00fe133c48cd16e1621ca6d5cf0b8e10d3b",
+        "accumulate_root": "0x7507515a48439dc58bc318c48a120b656136699f42bfd2bd45473becba53462d",
+        "work_packages": [
+            {
+                "hash": "0x3cc8d8c94e7b3ee01e678c63fd6b5db894fc807dff7fe10a11ab41e70194894d",
+                "exports_root": "0xc0edfe377d20b9f4ed7d9df9511ef904c87e24467364f0f7f75f20cfe90dd8fb"
+            }
+        ]
+    },
+    "pre_state": {
+        "beta": [
+            {
+                "header_hash": "0x530ef4636fedd498e99c7601581271894a53e965e901e8fa49581e525f165dae",
+                "mmr": {
+                    "peaks": [
+                        "0x8720b97ddd6acc0f6eb66e095524038675a4e4067adc10ec39939eaefc47d842"
+                    ]
+                },
+                "state_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "reported": [
+                    {
+                        "hash": "0x016cb55eb7b84e0d495d40832c7238965baeb468932c415dc2ceffe0afb039e5",
+                        "exports_root": "0x935f6dfef36fa06e10a9ba820f933611c05c06a207b07141fe8d87465870c11c"
+                    },
+                    {
+                        "hash": "0x76bcb24901299c331f0ca7342f4874f19b213ee72df613d50699e7e25edb82a6",
+                        "exports_root": "0xc825d16b7325ca90287123bd149d47843c999ce686ed51eaf8592dd2759272e3"
+                    }
+                ]
+            }
+        ]
+    },
+    "output": null,
+    "post_state": {
+        "beta": [
+            {
+                "header_hash": "0x530ef4636fedd498e99c7601581271894a53e965e901e8fa49581e525f165dae",
+                "mmr": {
+                    "peaks": [
+                        "0x8720b97ddd6acc0f6eb66e095524038675a4e4067adc10ec39939eaefc47d842"
+                    ]
+                },
+                "state_root": "0x1831dde64e40bfd8639c2d122e5ac00fe133c48cd16e1621ca6d5cf0b8e10d3b",
+                "reported": [
+                    {
+                        "hash": "0x016cb55eb7b84e0d495d40832c7238965baeb468932c415dc2ceffe0afb039e5",
+                        "exports_root": "0x935f6dfef36fa06e10a9ba820f933611c05c06a207b07141fe8d87465870c11c"
+                    },
+                    {
+                        "hash": "0x76bcb24901299c331f0ca7342f4874f19b213ee72df613d50699e7e25edb82a6",
+                        "exports_root": "0xc825d16b7325ca90287123bd149d47843c999ce686ed51eaf8592dd2759272e3"
+                    }
+                ]
+            },
+            {
+                "header_hash": "0x241d129c6edc2114e6dfba7d556f7f7c66399b55ceec3078a53d44c752ba7e9a",
+                "mmr": {
+                    "peaks": [
+                        null,
+                        "0x7076c31882a5953e097aef8378969945e72807c4705e53a0c5aacc9176f0d56b"
+                    ]
+                },
+                "state_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "reported": [
+                    {
+                        "hash": "0x3cc8d8c94e7b3ee01e678c63fd6b5db894fc807dff7fe10a11ab41e70194894d",
+                        "exports_root": "0xc0edfe377d20b9f4ed7d9df9511ef904c87e24467364f0f7f75f20cfe90dd8fb"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/integration/vectors/recenthistory/progress_blocks_history-3.json
+++ b/tests/integration/vectors/recenthistory/progress_blocks_history-3.json
@@ -1,0 +1,228 @@
+{
+    "input": {
+        "header_hash": "0x214facca26763b878b35a9fe988d3b0dd11428d17db1a56d743d678619ce3a08",
+        "parent_state_root": "0x8a812d298cde0b1d69bc0a2b32a7a36eb5dfff3dd7b20feca8e7087b447eee41",
+        "accumulate_root": "0x8223d5eaa57ccef85993b7180a593577fd38a65fb41e4bcea2933d8b202905f0",
+        "work_packages": [
+            {
+                "hash": "0x3d6e543fc243dbc082fc7768d5ec3050e2bf2f69389ef225ddacbfbb5e95d450",
+                "exports_root": "0x4fd3420ccf26786008a14a282f28ff1dc28413d7b602645eac8aaa921688c370"
+            }
+        ]
+    },
+    "pre_state": {
+        "beta": [
+            {
+                "header_hash": "0x530ef4636fedd498e99c7601581271894a53e965e901e8fa49581e525f165dae",
+                "mmr": {
+                    "peaks": [
+                        "0x8720b97ddd6acc0f6eb66e095524038675a4e4067adc10ec39939eaefc47d842"
+                    ]
+                },
+                "state_root": "0x1831dde64e40bfd8639c2d122e5ac00fe133c48cd16e1621ca6d5cf0b8e10d3b",
+                "reported": [
+                    {
+                        "hash": "0x016cb55eb7b84e0d495d40832c7238965baeb468932c415dc2ceffe0afb039e5",
+                        "exports_root": "0x935f6dfef36fa06e10a9ba820f933611c05c06a207b07141fe8d87465870c11c"
+                    },
+                    {
+                        "hash": "0x76bcb24901299c331f0ca7342f4874f19b213ee72df613d50699e7e25edb82a6",
+                        "exports_root": "0xc825d16b7325ca90287123bd149d47843c999ce686ed51eaf8592dd2759272e3"
+                    }
+                ]
+            },
+            {
+                "header_hash": "0x241d129c6edc2114e6dfba7d556f7f7c66399b55ceec3078a53d44c752ba7e9a",
+                "mmr": {
+                    "peaks": [
+                        null,
+                        "0x7076c31882a5953e097aef8378969945e72807c4705e53a0c5aacc9176f0d56b"
+                    ]
+                },
+                "state_root": "0xf9ca27d76e5daadae15ca8e36f05a234dcb19855d53edb66878dc857a678751c",
+                "reported": [
+                    {
+                        "hash": "0x3cc8d8c94e7b3ee01e678c63fd6b5db894fc807dff7fe10a11ab41e70194894d",
+                        "exports_root": "0xc0edfe377d20b9f4ed7d9df9511ef904c87e24467364f0f7f75f20cfe90dd8fb"
+                    }
+                ]
+            },
+            {
+                "header_hash": "0xc51005ebb96f1f6485d25e1ced6bed9c8443530de3a319c01ba12b2447905b7b",
+                "mmr": {
+                    "peaks": [
+                        "0xe99db82a25081fa6ed4b283161bf7b33439689db613124a2766acc9b4c5431e9",
+                        "0x7076c31882a5953e097aef8378969945e72807c4705e53a0c5aacc9176f0d56b"
+                    ]
+                },
+                "state_root": "0x47163fc0722d6b6e83437f1345a3f62e1dfe02e7b41d39cb4ff2a6f3bd120b21",
+                "reported": []
+            },
+            {
+                "header_hash": "0xf270b4d14f179593fb13ef13f9999fc81ecdd1664f4f143d3fdc609f8c970990",
+                "mmr": {
+                    "peaks": [
+                        null,
+                        null,
+                        "0xe17766e385ad36f22ff2357053ab8af6a6335331b90de2aa9c12ec9f397fa414"
+                    ]
+                },
+                "state_root": "0x09f858e15ae2d3a820166135d850b46f7d6f5df2719f96c5546007388811334a",
+                "reported": []
+            },
+            {
+                "header_hash": "0x24cca5dbb31594e81fee2c10266d65cc8f5184e841fd5f0992980f74b036ab19",
+                "mmr": {
+                    "peaks": [
+                        "0xc01cfd7b7f663d52d2d1490b359e0ad1b174dba145642a11babc83f0bc8139a8",
+                        null,
+                        "0xe17766e385ad36f22ff2357053ab8af6a6335331b90de2aa9c12ec9f397fa414"
+                    ]
+                },
+                "state_root": "0x99b3dd375039f0f03844625d3cde24d288d6b2e21fbe533646d91b1a5fb12719",
+                "reported": []
+            },
+            {
+                "header_hash": "0xf9667c1f2eee903bb96d130aeda4655887acc50ff12071b4aa6cc3c65e9ba96a",
+                "mmr": {
+                    "peaks": [
+                        null,
+                        "0xca29f72b6d40cfdb5814569cf906b3d369ae5f56b63d06f2b6bb47be191182a6",
+                        "0xe17766e385ad36f22ff2357053ab8af6a6335331b90de2aa9c12ec9f397fa414"
+                    ]
+                },
+                "state_root": "0xcfa88eb0966a61f0e7fffed57f7b004a4fffc51f9b40b6ae68db08ad5a61a39d",
+                "reported": []
+            },
+            {
+                "header_hash": "0xe9209ab342ae35c60e9cb755e4e169bbf5d9ed3b85a1a65c770535a6f0ed1981",
+                "mmr": {
+                    "peaks": [
+                        "0xf986bfeff7411437ca6a23163a96b5582e6739f261e697dc6f3c05a1ada1ed0c",
+                        "0xca29f72b6d40cfdb5814569cf906b3d369ae5f56b63d06f2b6bb47be191182a6",
+                        "0xe17766e385ad36f22ff2357053ab8af6a6335331b90de2aa9c12ec9f397fa414"
+                    ]
+                },
+                "state_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "reported": []
+            }
+        ]
+    },
+    "output": null,
+    "post_state": {
+        "beta": [
+            {
+                "header_hash": "0x530ef4636fedd498e99c7601581271894a53e965e901e8fa49581e525f165dae",
+                "mmr": {
+                    "peaks": [
+                        "0x8720b97ddd6acc0f6eb66e095524038675a4e4067adc10ec39939eaefc47d842"
+                    ]
+                },
+                "state_root": "0x1831dde64e40bfd8639c2d122e5ac00fe133c48cd16e1621ca6d5cf0b8e10d3b",
+                "reported": [
+                    {
+                        "hash": "0x016cb55eb7b84e0d495d40832c7238965baeb468932c415dc2ceffe0afb039e5",
+                        "exports_root": "0x935f6dfef36fa06e10a9ba820f933611c05c06a207b07141fe8d87465870c11c"
+                    },
+                    {
+                        "hash": "0x76bcb24901299c331f0ca7342f4874f19b213ee72df613d50699e7e25edb82a6",
+                        "exports_root": "0xc825d16b7325ca90287123bd149d47843c999ce686ed51eaf8592dd2759272e3"
+                    }
+                ]
+            },
+            {
+                "header_hash": "0x241d129c6edc2114e6dfba7d556f7f7c66399b55ceec3078a53d44c752ba7e9a",
+                "mmr": {
+                    "peaks": [
+                        null,
+                        "0x7076c31882a5953e097aef8378969945e72807c4705e53a0c5aacc9176f0d56b"
+                    ]
+                },
+                "state_root": "0xf9ca27d76e5daadae15ca8e36f05a234dcb19855d53edb66878dc857a678751c",
+                "reported": [
+                    {
+                        "hash": "0x3cc8d8c94e7b3ee01e678c63fd6b5db894fc807dff7fe10a11ab41e70194894d",
+                        "exports_root": "0xc0edfe377d20b9f4ed7d9df9511ef904c87e24467364f0f7f75f20cfe90dd8fb"
+                    }
+                ]
+            },
+            {
+                "header_hash": "0xc51005ebb96f1f6485d25e1ced6bed9c8443530de3a319c01ba12b2447905b7b",
+                "mmr": {
+                    "peaks": [
+                        "0xe99db82a25081fa6ed4b283161bf7b33439689db613124a2766acc9b4c5431e9",
+                        "0x7076c31882a5953e097aef8378969945e72807c4705e53a0c5aacc9176f0d56b"
+                    ]
+                },
+                "state_root": "0x47163fc0722d6b6e83437f1345a3f62e1dfe02e7b41d39cb4ff2a6f3bd120b21",
+                "reported": []
+            },
+            {
+                "header_hash": "0xf270b4d14f179593fb13ef13f9999fc81ecdd1664f4f143d3fdc609f8c970990",
+                "mmr": {
+                    "peaks": [
+                        null,
+                        null,
+                        "0xe17766e385ad36f22ff2357053ab8af6a6335331b90de2aa9c12ec9f397fa414"
+                    ]
+                },
+                "state_root": "0x09f858e15ae2d3a820166135d850b46f7d6f5df2719f96c5546007388811334a",
+                "reported": []
+            },
+            {
+                "header_hash": "0x24cca5dbb31594e81fee2c10266d65cc8f5184e841fd5f0992980f74b036ab19",
+                "mmr": {
+                    "peaks": [
+                        "0xc01cfd7b7f663d52d2d1490b359e0ad1b174dba145642a11babc83f0bc8139a8",
+                        null,
+                        "0xe17766e385ad36f22ff2357053ab8af6a6335331b90de2aa9c12ec9f397fa414"
+                    ]
+                },
+                "state_root": "0x99b3dd375039f0f03844625d3cde24d288d6b2e21fbe533646d91b1a5fb12719",
+                "reported": []
+            },
+            {
+                "header_hash": "0xf9667c1f2eee903bb96d130aeda4655887acc50ff12071b4aa6cc3c65e9ba96a",
+                "mmr": {
+                    "peaks": [
+                        null,
+                        "0xca29f72b6d40cfdb5814569cf906b3d369ae5f56b63d06f2b6bb47be191182a6",
+                        "0xe17766e385ad36f22ff2357053ab8af6a6335331b90de2aa9c12ec9f397fa414"
+                    ]
+                },
+                "state_root": "0xcfa88eb0966a61f0e7fffed57f7b004a4fffc51f9b40b6ae68db08ad5a61a39d",
+                "reported": []
+            },
+            {
+                "header_hash": "0xe9209ab342ae35c60e9cb755e4e169bbf5d9ed3b85a1a65c770535a6f0ed1981",
+                "mmr": {
+                    "peaks": [
+                        "0xf986bfeff7411437ca6a23163a96b5582e6739f261e697dc6f3c05a1ada1ed0c",
+                        "0xca29f72b6d40cfdb5814569cf906b3d369ae5f56b63d06f2b6bb47be191182a6",
+                        "0xe17766e385ad36f22ff2357053ab8af6a6335331b90de2aa9c12ec9f397fa414"
+                    ]
+                },
+                "state_root": "0x8a812d298cde0b1d69bc0a2b32a7a36eb5dfff3dd7b20feca8e7087b447eee41",
+                "reported": []
+            },
+            {
+                "header_hash": "0x214facca26763b878b35a9fe988d3b0dd11428d17db1a56d743d678619ce3a08",
+                "mmr": {
+                    "peaks": [
+                        null,
+                        null,
+                        null,
+                        "0x658b919f734bd39262c10589aa1afc657471d902a6a361c044f78de17d660bc6"
+                    ]
+                },
+                "state_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "reported": [
+                    {
+                        "hash": "0x3d6e543fc243dbc082fc7768d5ec3050e2bf2f69389ef225ddacbfbb5e95d450",
+                        "exports_root": "0x4fd3420ccf26786008a14a282f28ff1dc28413d7b602645eac8aaa921688c370"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/integration/vectors/recenthistory/progress_blocks_history-4.json
+++ b/tests/integration/vectors/recenthistory/progress_blocks_history-4.json
@@ -1,0 +1,245 @@
+{
+    "input": {
+        "header_hash": "0xad6862875431e427df25066819b82c648cf0c0d920904d58391a36a95bd9d481",
+        "parent_state_root": "0xa6aae15dfd6389e8f18e72a9dd6c03071e73c9a7f47df27415aaca0de068cb50",
+        "accumulate_root": "0xa983417440b618f29ed0b7fa65212fce2d363cb2b2c18871a05c4f67217290b0",
+        "work_packages": [
+            {
+                "hash": "0x1b03bc6eda0326c35df1b3f80fb1590016d29e1e9cef9b0b35853a1f6d069d7f",
+                "exports_root": "0x7d06ce0167ea77740512095c9f269f391ca620aa609a509fd5c979a5c0bfd4c0"
+            }
+        ]
+    },
+    "pre_state": {
+        "beta": [
+            {
+                "header_hash": "0x530ef4636fedd498e99c7601581271894a53e965e901e8fa49581e525f165dae",
+                "mmr": {
+                    "peaks": [
+                        "0x8720b97ddd6acc0f6eb66e095524038675a4e4067adc10ec39939eaefc47d842"
+                    ]
+                },
+                "state_root": "0x1831dde64e40bfd8639c2d122e5ac00fe133c48cd16e1621ca6d5cf0b8e10d3b",
+                "reported": [
+                    {
+                        "hash": "0x016cb55eb7b84e0d495d40832c7238965baeb468932c415dc2ceffe0afb039e5",
+                        "exports_root": "0x935f6dfef36fa06e10a9ba820f933611c05c06a207b07141fe8d87465870c11c"
+                    },
+                    {
+                        "hash": "0x76bcb24901299c331f0ca7342f4874f19b213ee72df613d50699e7e25edb82a6",
+                        "exports_root": "0xc825d16b7325ca90287123bd149d47843c999ce686ed51eaf8592dd2759272e3"
+                    }
+                ]
+            },
+            {
+                "header_hash": "0x241d129c6edc2114e6dfba7d556f7f7c66399b55ceec3078a53d44c752ba7e9a",
+                "mmr": {
+                    "peaks": [
+                        null,
+                        "0x7076c31882a5953e097aef8378969945e72807c4705e53a0c5aacc9176f0d56b"
+                    ]
+                },
+                "state_root": "0xf9ca27d76e5daadae15ca8e36f05a234dcb19855d53edb66878dc857a678751c",
+                "reported": [
+                    {
+                        "hash": "0x3cc8d8c94e7b3ee01e678c63fd6b5db894fc807dff7fe10a11ab41e70194894d",
+                        "exports_root": "0xc0edfe377d20b9f4ed7d9df9511ef904c87e24467364f0f7f75f20cfe90dd8fb"
+                    }
+                ]
+            },
+            {
+                "header_hash": "0xc51005ebb96f1f6485d25e1ced6bed9c8443530de3a319c01ba12b2447905b7b",
+                "mmr": {
+                    "peaks": [
+                        "0xe99db82a25081fa6ed4b283161bf7b33439689db613124a2766acc9b4c5431e9",
+                        "0x7076c31882a5953e097aef8378969945e72807c4705e53a0c5aacc9176f0d56b"
+                    ]
+                },
+                "state_root": "0x47163fc0722d6b6e83437f1345a3f62e1dfe02e7b41d39cb4ff2a6f3bd120b21",
+                "reported": []
+            },
+            {
+                "header_hash": "0xf270b4d14f179593fb13ef13f9999fc81ecdd1664f4f143d3fdc609f8c970990",
+                "mmr": {
+                    "peaks": [
+                        null,
+                        null,
+                        "0xe17766e385ad36f22ff2357053ab8af6a6335331b90de2aa9c12ec9f397fa414"
+                    ]
+                },
+                "state_root": "0x09f858e15ae2d3a820166135d850b46f7d6f5df2719f96c5546007388811334a",
+                "reported": []
+            },
+            {
+                "header_hash": "0x24cca5dbb31594e81fee2c10266d65cc8f5184e841fd5f0992980f74b036ab19",
+                "mmr": {
+                    "peaks": [
+                        "0xc01cfd7b7f663d52d2d1490b359e0ad1b174dba145642a11babc83f0bc8139a8",
+                        null,
+                        "0xe17766e385ad36f22ff2357053ab8af6a6335331b90de2aa9c12ec9f397fa414"
+                    ]
+                },
+                "state_root": "0x99b3dd375039f0f03844625d3cde24d288d6b2e21fbe533646d91b1a5fb12719",
+                "reported": []
+            },
+            {
+                "header_hash": "0xf9667c1f2eee903bb96d130aeda4655887acc50ff12071b4aa6cc3c65e9ba96a",
+                "mmr": {
+                    "peaks": [
+                        null,
+                        "0xca29f72b6d40cfdb5814569cf906b3d369ae5f56b63d06f2b6bb47be191182a6",
+                        "0xe17766e385ad36f22ff2357053ab8af6a6335331b90de2aa9c12ec9f397fa414"
+                    ]
+                },
+                "state_root": "0xcfa88eb0966a61f0e7fffed57f7b004a4fffc51f9b40b6ae68db08ad5a61a39d",
+                "reported": []
+            },
+            {
+                "header_hash": "0xe9209ab342ae35c60e9cb755e4e169bbf5d9ed3b85a1a65c770535a6f0ed1981",
+                "mmr": {
+                    "peaks": [
+                        "0xf986bfeff7411437ca6a23163a96b5582e6739f261e697dc6f3c05a1ada1ed0c",
+                        "0xca29f72b6d40cfdb5814569cf906b3d369ae5f56b63d06f2b6bb47be191182a6",
+                        "0xe17766e385ad36f22ff2357053ab8af6a6335331b90de2aa9c12ec9f397fa414"
+                    ]
+                },
+                "state_root": "0x8a812d298cde0b1d69bc0a2b32a7a36eb5dfff3dd7b20feca8e7087b447eee41",
+                "reported": []
+            },
+            {
+                "header_hash": "0x214facca26763b878b35a9fe988d3b0dd11428d17db1a56d743d678619ce3a08",
+                "mmr": {
+                    "peaks": [
+                        null,
+                        null,
+                        null,
+                        "0x658b919f734bd39262c10589aa1afc657471d902a6a361c044f78de17d660bc6"
+                    ]
+                },
+                "state_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "reported": [
+                    {
+                        "hash": "0x3d6e543fc243dbc082fc7768d5ec3050e2bf2f69389ef225ddacbfbb5e95d450",
+                        "exports_root": "0x4fd3420ccf26786008a14a282f28ff1dc28413d7b602645eac8aaa921688c370"
+                    }
+                ]
+            }
+        ]
+    },
+    "output": null,
+    "post_state": {
+        "beta": [
+            {
+                "header_hash": "0x241d129c6edc2114e6dfba7d556f7f7c66399b55ceec3078a53d44c752ba7e9a",
+                "mmr": {
+                    "peaks": [
+                        null,
+                        "0x7076c31882a5953e097aef8378969945e72807c4705e53a0c5aacc9176f0d56b"
+                    ]
+                },
+                "state_root": "0xf9ca27d76e5daadae15ca8e36f05a234dcb19855d53edb66878dc857a678751c",
+                "reported": [
+                    {
+                        "hash": "0x3cc8d8c94e7b3ee01e678c63fd6b5db894fc807dff7fe10a11ab41e70194894d",
+                        "exports_root": "0xc0edfe377d20b9f4ed7d9df9511ef904c87e24467364f0f7f75f20cfe90dd8fb"
+                    }
+                ]
+            },
+            {
+                "header_hash": "0xc51005ebb96f1f6485d25e1ced6bed9c8443530de3a319c01ba12b2447905b7b",
+                "mmr": {
+                    "peaks": [
+                        "0xe99db82a25081fa6ed4b283161bf7b33439689db613124a2766acc9b4c5431e9",
+                        "0x7076c31882a5953e097aef8378969945e72807c4705e53a0c5aacc9176f0d56b"
+                    ]
+                },
+                "state_root": "0x47163fc0722d6b6e83437f1345a3f62e1dfe02e7b41d39cb4ff2a6f3bd120b21",
+                "reported": []
+            },
+            {
+                "header_hash": "0xf270b4d14f179593fb13ef13f9999fc81ecdd1664f4f143d3fdc609f8c970990",
+                "mmr": {
+                    "peaks": [
+                        null,
+                        null,
+                        "0xe17766e385ad36f22ff2357053ab8af6a6335331b90de2aa9c12ec9f397fa414"
+                    ]
+                },
+                "state_root": "0x09f858e15ae2d3a820166135d850b46f7d6f5df2719f96c5546007388811334a",
+                "reported": []
+            },
+            {
+                "header_hash": "0x24cca5dbb31594e81fee2c10266d65cc8f5184e841fd5f0992980f74b036ab19",
+                "mmr": {
+                    "peaks": [
+                        "0xc01cfd7b7f663d52d2d1490b359e0ad1b174dba145642a11babc83f0bc8139a8",
+                        null,
+                        "0xe17766e385ad36f22ff2357053ab8af6a6335331b90de2aa9c12ec9f397fa414"
+                    ]
+                },
+                "state_root": "0x99b3dd375039f0f03844625d3cde24d288d6b2e21fbe533646d91b1a5fb12719",
+                "reported": []
+            },
+            {
+                "header_hash": "0xf9667c1f2eee903bb96d130aeda4655887acc50ff12071b4aa6cc3c65e9ba96a",
+                "mmr": {
+                    "peaks": [
+                        null,
+                        "0xca29f72b6d40cfdb5814569cf906b3d369ae5f56b63d06f2b6bb47be191182a6",
+                        "0xe17766e385ad36f22ff2357053ab8af6a6335331b90de2aa9c12ec9f397fa414"
+                    ]
+                },
+                "state_root": "0xcfa88eb0966a61f0e7fffed57f7b004a4fffc51f9b40b6ae68db08ad5a61a39d",
+                "reported": []
+            },
+            {
+                "header_hash": "0xe9209ab342ae35c60e9cb755e4e169bbf5d9ed3b85a1a65c770535a6f0ed1981",
+                "mmr": {
+                    "peaks": [
+                        "0xf986bfeff7411437ca6a23163a96b5582e6739f261e697dc6f3c05a1ada1ed0c",
+                        "0xca29f72b6d40cfdb5814569cf906b3d369ae5f56b63d06f2b6bb47be191182a6",
+                        "0xe17766e385ad36f22ff2357053ab8af6a6335331b90de2aa9c12ec9f397fa414"
+                    ]
+                },
+                "state_root": "0x8a812d298cde0b1d69bc0a2b32a7a36eb5dfff3dd7b20feca8e7087b447eee41",
+                "reported": []
+            },
+            {
+                "header_hash": "0x214facca26763b878b35a9fe988d3b0dd11428d17db1a56d743d678619ce3a08",
+                "mmr": {
+                    "peaks": [
+                        null,
+                        null,
+                        null,
+                        "0x658b919f734bd39262c10589aa1afc657471d902a6a361c044f78de17d660bc6"
+                    ]
+                },
+                "state_root": "0xa6aae15dfd6389e8f18e72a9dd6c03071e73c9a7f47df27415aaca0de068cb50",
+                "reported": [
+                    {
+                        "hash": "0x3d6e543fc243dbc082fc7768d5ec3050e2bf2f69389ef225ddacbfbb5e95d450",
+                        "exports_root": "0x4fd3420ccf26786008a14a282f28ff1dc28413d7b602645eac8aaa921688c370"
+                    }
+                ]
+            },
+            {
+                "header_hash": "0xad6862875431e427df25066819b82c648cf0c0d920904d58391a36a95bd9d481",
+                "mmr": {
+                    "peaks": [
+                        "0xa983417440b618f29ed0b7fa65212fce2d363cb2b2c18871a05c4f67217290b0",
+                        null,
+                        null,
+                        "0x658b919f734bd39262c10589aa1afc657471d902a6a361c044f78de17d660bc6"
+                    ]
+                },
+                "state_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "reported": [
+                    {
+                        "hash": "0x1b03bc6eda0326c35df1b3f80fb1590016d29e1e9cef9b0b35853a1f6d069d7f",
+                        "exports_root": "0x7d06ce0167ea77740512095c9f269f391ca620aa609a509fd5c979a5c0bfd4c0"
+                    }
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
- Separate core logic for updating recent history for simpler integration tests.
- Add recent history test vectors, and integration test.
- Fix bug in MMR. We shouldn't always hash the input.

Closes #137 