### PR TITLE
Add certificate generation and validation

### DIFF
--- a/pkg/network/cert/cert.go
+++ b/pkg/network/cert/cert.go
@@ -1,0 +1,113 @@
+package cert
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base32"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+)
+
+const (
+	DNSNamePrefix = "e"
+)
+
+var base32Encoding = base32.NewEncoding("abcdefghijklmnopqrstuvwxyz234567").WithPadding(base32.NoPadding)
+
+type Config struct {
+	PublicKey          ed25519.PublicKey
+	PrivateKey         ed25519.PrivateKey
+	CertValidityPeriod time.Duration
+}
+
+type Generator struct {
+	config Config
+}
+
+func NewGenerator(config Config) *Generator {
+	return &Generator{config: config}
+}
+
+func encodePubKeyToDNS(pubKey ed25519.PublicKey) string {
+	return DNSNamePrefix + base32Encoding.EncodeToString(pubKey)
+}
+
+func (g *Generator) GenerateCertificate() (*x509.Certificate, error) {
+	dnsName := encodePubKeyToDNS(g.config.PublicKey)
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: dnsName,
+		},
+		DNSNames:  []string{dnsName},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(g.config.CertValidityPeriod),
+		KeyUsage:  x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		},
+		BasicConstraintsValid: true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, g.config.PublicKey, g.config.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create certificate: %w", err)
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse certificate: %w", err)
+	}
+
+	return cert, nil
+}
+
+func ValidateCertificate(cert *x509.Certificate) error {
+	// Check signature algorithm
+	if cert.SignatureAlgorithm != x509.PureEd25519 {
+		return fmt.Errorf("invalid signature algorithm: expected Ed25519")
+	}
+
+	// Check DNS names
+	if len(cert.DNSNames) != 1 {
+		return fmt.Errorf("certificate must have exactly one DNS name")
+	}
+	dnsName := cert.DNSNames[0]
+
+	// Verify format
+	if len(dnsName) != 53 || !strings.HasPrefix(dnsName, DNSNamePrefix) {
+		return fmt.Errorf("invalid DNS name format: %s", dnsName)
+	}
+
+	// Validate public key
+	pubKey, ok := cert.PublicKey.(ed25519.PublicKey)
+	if !ok {
+		return fmt.Errorf("certificate public key is not an Ed25519 key")
+	}
+	expectedDNSName := encodePubKeyToDNS(pubKey)
+	if dnsName != expectedDNSName {
+		return fmt.Errorf("DNS name does not match public key: got %s, expected %s", dnsName, expectedDNSName)
+	}
+
+	// Check expiration
+	now := time.Now()
+	if now.Before(cert.NotBefore) {
+		return fmt.Errorf("certificate is not yet valid: valid from %v", cert.NotBefore)
+	}
+	if now.After(cert.NotAfter) {
+		return fmt.Errorf("certificate has expired: valid until %v", cert.NotAfter)
+	}
+
+	return nil
+}

--- a/pkg/network/cert/cert_test.go
+++ b/pkg/network/cert/cert_test.go
@@ -1,0 +1,145 @@
+package cert
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateCertificateSuccess(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err, "Failed to generate Ed25519 key pair")
+
+	config := Config{
+		PublicKey:          pub,
+		PrivateKey:         priv,
+		CertValidityPeriod: 24 * time.Hour,
+	}
+
+	generator := NewGenerator(config)
+	cert, err := generator.GenerateCertificate()
+
+	require.NoError(t, err, "Failed to generate certificate")
+	assert.NotNil(t, cert, "Generated certificate should not be nil")
+}
+
+func TestValidateCertificateSuccess(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err, "Failed to generate Ed25519 key pair")
+
+	config := Config{
+		PublicKey:          pub,
+		PrivateKey:         priv,
+		CertValidityPeriod: 24 * time.Hour,
+	}
+	generator := NewGenerator(config)
+	cert, err := generator.GenerateCertificate()
+	require.NoError(t, err, "Failed to generate certificate")
+
+	err = ValidateCertificate(cert)
+	assert.NoError(t, err, "Valid certificate failed validation")
+}
+
+func TestValidateCertificateFailsForMismatchedPublicKey(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err, "Failed to generate Ed25519 key pair")
+
+	config := Config{
+		PublicKey:          pub,
+		PrivateKey:         priv,
+		CertValidityPeriod: 24 * time.Hour,
+	}
+	generator := NewGenerator(config)
+	cert, err := generator.GenerateCertificate()
+	require.NoError(t, err, "Failed to generate certificate")
+
+	// Tamper with the public key
+	wrongPub, _, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err, "Failed to generate a new Ed25519 key pair")
+	cert.PublicKey = wrongPub
+
+	err = ValidateCertificate(cert)
+	assert.Error(t, err, "Expected validation to fail for certificate with mismatched DNS name and public key")
+}
+
+func TestCertificateDNSNameFormat(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err, "Failed to generate Ed25519 key pair")
+
+	config := Config{
+		PublicKey:          pub,
+		PrivateKey:         priv,
+		CertValidityPeriod: 24 * time.Hour,
+	}
+	generator := NewGenerator(config)
+	cert, err := generator.GenerateCertificate()
+	require.NoError(t, err, "Failed to generate certificate")
+
+	require.Len(t, cert.DNSNames, 1, "Certificate must have exactly one DNS name")
+	dnsName := cert.DNSNames[0]
+	assert.Equal(t, 53, len(dnsName), "DNS name should be 53 characters long")
+	assert.True(t, dnsName[0] == 'e', "DNS name should start with 'e'")
+}
+
+func TestCertificateParseDER(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err, "Failed to generate Ed25519 key pair")
+
+	config := Config{
+		PublicKey:          pub,
+		PrivateKey:         priv,
+		CertValidityPeriod: 24 * time.Hour,
+	}
+	generator := NewGenerator(config)
+	cert, err := generator.GenerateCertificate()
+	require.NoError(t, err, "Failed to generate certificate")
+
+	parsedCert, err := x509.ParseCertificate(cert.Raw)
+	assert.NoError(t, err, "Failed to parse generated certificate DER")
+	assert.NotNil(t, parsedCert, "Parsed certificate should not be nil")
+}
+
+func TestValidateCertificateExpired(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err, "Failed to generate Ed25519 key pair")
+
+	// Create a certificate with a validity period in the past
+	config := Config{
+		PublicKey:          pub,
+		PrivateKey:         priv,
+		CertValidityPeriod: -1 * time.Hour, // Expired 1 hour ago
+	}
+	generator := NewGenerator(config)
+	cert, err := generator.GenerateCertificate()
+	require.NoError(t, err, "Failed to generate expired certificate")
+
+	// Validate the certificate
+	err = ValidateCertificate(cert)
+	assert.Error(t, err, "Expected validation to fail for expired certificate")
+	assert.Contains(t, err.Error(), "certificate has expired", "Expected error message for expired certificate")
+}
+
+func TestValidateCertificateFutureStartDate(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err, "Failed to generate Ed25519 key pair")
+
+	// Create a certificate with a validity period starting in the future
+	config := Config{
+		PublicKey:          pub,
+		PrivateKey:         priv,
+		CertValidityPeriod: 24 * time.Hour, // Validity starts tomorrow
+	}
+	generator := NewGenerator(config)
+	cert, err := generator.GenerateCertificate()
+	require.NoError(t, err, "Failed to generate future-dated certificate")
+	cert.NotBefore = time.Now().Add(1 * time.Hour) // Adjust NotBefore to 1 hour from now
+
+	// Validate the certificate
+	err = ValidateCertificate(cert)
+	assert.Error(t, err, "Expected validation to fail for not-yet-valid certificate")
+	assert.Contains(t, err.Error(), "certificate is not yet valid", "Expected error message for future-dated certificate")
+}


### PR DESCRIPTION
This is just a generate/validate self signed cert.
The relevant part from the https://github.com/zdave-parity/jam-np/blob/main/simple.md:
```During the TLS handshake, both the client (the peer that initiated the connection) and the server (the peer that accepted the connection) must present X.509 certificates. A peer's certificate must:

Use Ed25519 as the signature algorithm.
Use the peer's Ed25519 key. If the peer is a validator, this key should have been published on chain.
Have a single alternative name, which must be a 53-character DNS name consisting of "e" followed by the Ed25519 public key, base-32 encoded using the alphabet "abcdefghijklmnopqrstuvwxyz234567".
The certificates should be self-signed, however this is not required and need not be verified.