### PR TITLE
Add alpn protocol ID

### DIFF
--- a/pkg/network/transport/protocol/alpn.go
+++ b/pkg/network/transport/protocol/alpn.go
@@ -1,0 +1,106 @@
+package transport
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	// Protocol prefix for JAMNP-S
+	protocolPrefix = "jamnp-s"
+
+	// Current protocol version
+	currentVersion = "0"
+
+	// Builder suffix for builder connections
+	builderSuffix = "builder"
+
+	// Chain hash length in nibbles
+	chainHashLength = 8
+)
+
+// ProtocolID represents a complete ALPN protocol identifier
+type ProtocolID struct {
+	Version   string
+	ChainHash string
+	IsBuilder bool
+}
+
+// NewProtocolID creates a new ProtocolID with the given parameters
+func NewProtocolID(chainHash string, isBuilder bool) *ProtocolID {
+	return &ProtocolID{
+		Version:   currentVersion,
+		ChainHash: chainHash,
+		IsBuilder: isBuilder,
+	}
+}
+
+// String converts the ProtocolID to its string representation
+func (p *ProtocolID) String() string {
+	parts := []string{protocolPrefix, p.Version, p.ChainHash}
+	if p.IsBuilder {
+		parts = append(parts, builderSuffix)
+	}
+	return strings.Join(parts, "/")
+}
+
+// ParseProtocolID parses an ALPN protocol string into a ProtocolID
+func ParseProtocolID(protocol string) (*ProtocolID, error) {
+	parts := strings.Split(protocol, "/")
+
+	// Validate basic format
+	if len(parts) < 3 || len(parts) > 4 {
+		return nil, fmt.Errorf("invalid protocol format: %s", protocol)
+	}
+
+	// Validate prefix
+	if parts[0] != protocolPrefix {
+		return nil, fmt.Errorf("invalid protocol prefix: %s", parts[0])
+	}
+
+	// Validate version
+	if parts[1] != currentVersion {
+		return nil, fmt.Errorf("unsupported protocol version: %s", parts[1])
+	}
+
+	// Validate chain hash format (8 hex nibbles)
+	chainHash := parts[2]
+	if len(chainHash) != chainHashLength {
+		return nil, fmt.Errorf("invalid chain hash length: %s", chainHash)
+	}
+	for _, c := range chainHash {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return nil, fmt.Errorf("invalid chain hash character: %c", c)
+		}
+	}
+
+	// Check for builder suffix
+	isBuilder := false
+	if len(parts) == 4 {
+		if strings.ToLower(parts[3]) != builderSuffix {
+			return nil, fmt.Errorf("invalid protocol suffix: %s", parts[3])
+		}
+
+		isBuilder = true
+	}
+
+	return &ProtocolID{
+		Version:   parts[1],
+		ChainHash: chainHash,
+		IsBuilder: isBuilder,
+	}, nil
+}
+
+// ValidateALPNProtocol validates an ALPN protocol string according to the JAMNP-S specification
+func ValidateALPNProtocol(protocol string) error {
+	_, err := ParseProtocolID(protocol)
+	return err
+}
+
+// AcceptableProtocols returns all acceptable protocol strings for a given chain hash
+func AcceptableProtocols(chainHash string) []string {
+	return []string{
+		NewProtocolID(chainHash, false).String(),
+		NewProtocolID(chainHash, true).String(),
+	}
+}

--- a/pkg/network/transport/protocol/alpn_test.go
+++ b/pkg/network/transport/protocol/alpn_test.go
@@ -1,0 +1,149 @@
+package transport
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestProtocolIDString(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    *ProtocolID
+		expected string
+	}{
+		{
+			name: "Regular Protocol",
+			input: &ProtocolID{
+				Version:   currentVersion,
+				ChainHash: "abcd1234",
+				IsBuilder: false,
+			},
+			expected: "jamnp-s/" + currentVersion + "/abcd1234",
+		},
+		{
+			name: "Builder Protocol",
+			input: &ProtocolID{
+				Version:   currentVersion,
+				ChainHash: "abcd1234",
+				IsBuilder: true,
+			},
+			expected: "jamnp-s/" + currentVersion + "/abcd1234/builder",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.input.String()
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestParseProtocolID_Valid(t *testing.T) {
+	validTestCases := []struct {
+		name     string
+		input    string
+		expected *ProtocolID
+	}{
+		{
+			name:  "Regular Protocol",
+			input: "jamnp-s/" + currentVersion + "/abcd1234",
+			expected: &ProtocolID{
+				Version:   currentVersion,
+				ChainHash: "abcd1234",
+				IsBuilder: false,
+			},
+		},
+		{
+			name:  "Builder Protocol",
+			input: "jamnp-s/" + currentVersion + "/abcd1234/builder",
+			expected: &ProtocolID{
+				Version:   currentVersion,
+				ChainHash: "abcd1234",
+				IsBuilder: true,
+			},
+		},
+	}
+
+	for _, tc := range validTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ParseProtocolID(tc.input)
+			require.NoError(t, err, "Expected no error for valid input")
+			assert.Equal(t, tc.expected.Version, result.Version, "Version mismatch")
+			assert.Equal(t, tc.expected.ChainHash, result.ChainHash, "ChainHash mismatch")
+			assert.Equal(t, tc.expected.IsBuilder, result.IsBuilder, "IsBuilder mismatch")
+		})
+	}
+}
+
+func TestParseProtocolID_Invalid(t *testing.T) {
+	invalidTestCases := []struct {
+		name          string
+		input         string
+		expectedError string
+	}{
+		{name: "Empty String", input: "", expectedError: "invalid protocol format"},
+		{name: "Invalid Prefix", input: "invalid/" + currentVersion + "/abcd1234", expectedError: "invalid protocol prefix"},
+		{name: "Invalid Version", input: "jamnp-s/99/abcd1234", expectedError: "unsupported protocol version"},
+		{name: "Invalid Chain Hash Length", input: "jamnp-s/" + currentVersion + "/abc123", expectedError: "invalid chain hash length"},
+		{name: "Invalid Chain Hash Characters", input: "jamnp-s/" + currentVersion + "/abcdxxxx", expectedError: "invalid chain hash character"},
+		{name: "Invalid Builder Suffix", input: "jamnp-s/" + currentVersion + "/abcd1234/invalid", expectedError: "invalid protocol suffix"},
+		{name: "Too Many Parts", input: "jamnp-s/" + currentVersion + "/abcd1234/builder/extra", expectedError: "invalid protocol format"},
+	}
+
+	for _, tc := range invalidTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseProtocolID(tc.input)
+			require.Error(t, err, "Expected error for invalid input")
+			assert.Contains(t, err.Error(), tc.expectedError, "Unexpected error message")
+		})
+	}
+}
+
+func TestAcceptableProtocols(t *testing.T) {
+	chainHash := "abcd1234"
+	expected := []string{
+		"jamnp-s/" + currentVersion + "/abcd1234",
+		"jamnp-s/" + currentVersion + "/abcd1234/builder",
+	}
+
+	result := AcceptableProtocols(chainHash)
+	assert.Equal(t, expected, result, "acceptable protocols should match expected list")
+}
+
+func TestValidateALPNProtocol_Valid(t *testing.T) {
+	validProtocols := []string{
+		"jamnp-s/" + currentVersion + "/abcd1234",
+		"jamnp-s/" + currentVersion + "/abcd1234/builder",
+		"jamnp-s/" + currentVersion + "/deadbeef",
+		"jamnp-s/" + currentVersion + "/deadbeef/builder",
+	}
+
+	for _, protocol := range validProtocols {
+		t.Run("Valid: "+protocol, func(t *testing.T) {
+			err := ValidateALPNProtocol(protocol)
+			assert.NoError(t, err, "Expected protocol to be valid: %s", protocol)
+		})
+	}
+}
+
+func TestValidateALPNProtocol_Invalid(t *testing.T) {
+	invalidProtocols := []string{
+		"",
+		"jamnp-s",
+		"jamnp-s/" + currentVersion + "",
+		"jamnp-s/99/abcd1234",
+		"jamnp-s/" + currentVersion + "/abcd123",
+		"jamnp-s/" + currentVersion + "/abcd123g",
+		"jamnp-s/" + currentVersion + "/abcd1234/invalid",
+		"invalid/" + currentVersion + "/abcd1234",
+	}
+
+	for _, protocol := range invalidProtocols {
+		t.Run("Invalid: "+protocol, func(t *testing.T) {
+			err := ValidateALPNProtocol(protocol)
+			assert.Error(t, err, "Expected protocol to be invalid: %s", protocol)
+		})
+	}
+}


### PR DESCRIPTION
```The protocol name, version, and chain are identified using QUIC/TLS "ALPN" (Application Layer Protocol Negotiation). The (ASCII-encoded) protocol identifier should be either jamnp-s/V/H or jamnp-s/V/H/builder. Here V is the protocol version, 0, and H is the first 8 nibbles of the hash of the chain's genesis header, in lower-case hexadecimal.```