### PR TITLE
Add SAFROLE ticket simulation

### DIFF
--- a/internal/crypto/bandersnatch/bandersnatch.go
+++ b/internal/crypto/bandersnatch/bandersnatch.go
@@ -219,7 +219,7 @@ func NewRingVerifier(publicKeys []crypto.BandersnatchPublicKey) (*RingVrfVerifie
 // Frees the RingVrfVerifier on the Rust side. Must be called to avoid memory
 // leaks.
 func (r *RingVrfVerifier) Free() {
-	if r.ptr != nil {
+	if r != nil && r.ptr != nil {
 		freeRingVrfVerifier(r.ptr)
 		r.ptr = nil
 	}
@@ -239,7 +239,7 @@ func flattenPublicKeys(keys []crypto.BandersnatchPublicKey) []byte {
 // Get the KZG commitment of the ring. This is used to verify ring signatures
 // more efficiently. It's stored as gamma_z in SAFROLE state.
 func (r *RingVrfVerifier) Commitment() (commitment crypto.RingCommitment, err error) {
-	if r.ptr == nil {
+	if r == nil || r.ptr == nil {
 		return crypto.RingCommitment{}, errors.New("nil RingVrfVerifier")
 	}
 
@@ -261,7 +261,7 @@ func (r *RingVrfVerifier) Verify(
 	commitment crypto.RingCommitment,
 	signature crypto.RingVrfSignature,
 ) (valid bool, outputHash crypto.BandersnatchOutputHash) {
-	if r.ptr == nil {
+	if r == nil || r.ptr == nil {
 		panic("nil RingVrfVerifier")
 	}
 
@@ -300,7 +300,7 @@ func NewRingProver(secret crypto.BandersnatchPrivateKey, publicKeys []crypto.Ban
 // Frees the RingVrfProver on the Rust side. Must be called to avoid memory
 // leaks.
 func (r *RingVrfProver) Free() {
-	if r.ptr != nil {
+	if r != nil && r.ptr != nil {
 		freeRingVrfProver(r.ptr)
 		r.ptr = nil
 	}
@@ -312,7 +312,7 @@ func (r *RingVrfProver) Free() {
 // output hash of the signature depends soley on vrfInputData. Used for ticket
 // submission.
 func (r *RingVrfProver) Sign(vrfInputData []byte, auxData []byte) (signature crypto.RingVrfSignature, err error) {
-	if r.ptr == nil {
+	if r == nil || r.ptr == nil {
 		return crypto.RingVrfSignature{}, errors.New("nil RingVrfProver")
 	}
 

--- a/internal/safrole/state.go
+++ b/internal/safrole/state.go
@@ -70,7 +70,7 @@ func (state State) RingProver(privateKey crypto.BandersnatchPrivateKey) (*bander
 		return nil, fmt.Errorf("private key is not a ring member")
 	}
 
-	ringProver, err := bandersnatch.NewRingProver(privateKey, ring, uint(proverIdx))
+	return bandersnatch.NewRingProver(privateKey, ring, uint(proverIdx))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/safrole/state.go
+++ b/internal/safrole/state.go
@@ -37,11 +37,7 @@ func (state State) RingVerifier() (*bandersnatch.RingVrfVerifier, error) {
 	for i, vd := range state.NextValidators {
 		ring[i] = vd.Bandersnatch
 	}
-	ringVerifier, err := bandersnatch.NewRingVerifier(ring)
-	if err != nil {
-		return nil, err
-	}
-	return ringVerifier, nil
+	return bandersnatch.NewRingVerifier(ring)
 }
 
 // Takes a private bandersnatch key and returns a new RingVrfProver for this state.
@@ -71,10 +67,6 @@ func (state State) RingProver(privateKey crypto.BandersnatchPrivateKey) (*bander
 	}
 
 	return bandersnatch.NewRingProver(privateKey, ring, uint(proverIdx))
-	if err != nil {
-		return nil, err
-	}
-	return ringProver, nil
 }
 
 // SelectFallbackKeys selects the fallback keys for the sealing key series.

--- a/internal/safrole/state.go
+++ b/internal/safrole/state.go
@@ -1,6 +1,8 @@
 package safrole
 
 import (
+	"fmt"
+
 	"github.com/eigerco/strawberry/internal/block"
 	"github.com/eigerco/strawberry/internal/common"
 	"github.com/eigerco/strawberry/internal/crypto"
@@ -40,6 +42,39 @@ func (state State) RingVerifier() (*bandersnatch.RingVrfVerifier, error) {
 		return nil, err
 	}
 	return ringVerifier, nil
+}
+
+// Takes a private bandersnatch key and returns a new RingVrfProver for this state.
+func (state State) RingProver(privateKey crypto.BandersnatchPrivateKey) (*bandersnatch.RingVrfProver, error) {
+	publicKey, err := bandersnatch.Public(privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	ring := make([]crypto.BandersnatchPublicKey, len(state.NextValidators))
+	for i, vd := range state.NextValidators {
+		ring[i] = vd.Bandersnatch
+	}
+
+	// Find the prover index in the ring, if we don't find a match we return an
+	// error.
+	proverIdx := 0
+	found := false
+	for i, pk := range ring {
+		if pk == publicKey {
+			proverIdx = i
+			found = true
+		}
+	}
+	if !found {
+		return nil, fmt.Errorf("private key is not a ring member")
+	}
+
+	ringProver, err := bandersnatch.NewRingProver(privateKey, ring, uint(proverIdx))
+	if err != nil {
+		return nil, err
+	}
+	return ringProver, nil
 }
 
 // SelectFallbackKeys selects the fallback keys for the sealing key series.

--- a/internal/state/block_seal.go
+++ b/internal/state/block_seal.go
@@ -119,7 +119,6 @@ func SignBlockWithTicket(
 	vrfSignature crypto.BandersnatchSignature,
 	err error,
 ) {
-
 	// Build the context: XT ⌢ η′3 ++ ir
 	sealContext := buildTicketSealContext(entropy, ticket.EntryIndex)
 

--- a/internal/state/ticket.go
+++ b/internal/state/ticket.go
@@ -1,0 +1,63 @@
+package state
+
+import (
+	"errors"
+
+	"github.com/eigerco/strawberry/internal/block"
+	"github.com/eigerco/strawberry/internal/common"
+	"github.com/eigerco/strawberry/internal/crypto"
+)
+
+// Creates a ticket proof as per equation 6.29 in the graypaper (v0.6.4)
+// The ticket extrinic is a sequence of ticket proofs.
+func CreateTicketProof(state *State, privateKey crypto.BandersnatchPrivateKey, attempt uint8) (block.TicketProof, error) {
+	if attempt > common.MaxTicketAttempts {
+		return block.TicketProof{}, errors.New("attempts exceeded")
+	}
+
+	ringProver, err := state.ValidatorState.SafroleState.RingProver(privateKey)
+	defer ringProver.Free()
+	if err != nil {
+		return block.TicketProof{}, err
+	}
+
+	// Build the context: XT ⌢ η′2 ++ ir
+	context := buildTicketSealContext(state.EntropyPool[2], attempt)
+	// Produce an anonymous ring signature.
+	signature, err := ringProver.Sign(context, []byte{})
+	if err != nil {
+		return block.TicketProof{}, err
+	}
+
+	ticket := block.TicketProof{
+		EntryIndex: attempt,
+		Proof:      signature,
+	}
+
+	return ticket, nil
+}
+
+// Verifies a ticket proof as per equation 6.29 in the graypaper (v0.6.4)
+// Returns the output hash / identifier of the ticket if the proof is valid, or
+// an error if it is not.
+func VerifyTicketProof(state *State, ticket block.TicketProof) (crypto.BandersnatchOutputHash, error) {
+	// TODO: if this is too expensive to construct each time we should pass it in.
+	ringVerifier, err := state.ValidatorState.SafroleState.RingVerifier()
+	defer ringVerifier.Free()
+	if err != nil {
+		return crypto.BandersnatchOutputHash{}, err
+	}
+
+	if ticket.EntryIndex >= common.MaxTicketAttempts {
+		return crypto.BandersnatchOutputHash{}, errors.New("bad ticket attempt")
+	}
+
+	// Build the context: XT ⌢ η′2 ++ ir
+	context := buildTicketSealContext(state.EntropyPool[2], ticket.EntryIndex)
+	ok, outputHash := ringVerifier.Verify(context, []byte{}, state.ValidatorState.SafroleState.RingCommitment, ticket.Proof)
+	if !ok {
+		return crypto.BandersnatchOutputHash{}, errors.New("bad ticket proof")
+	}
+
+	return outputHash, nil
+}

--- a/internal/state/ticket_test.go
+++ b/internal/state/ticket_test.go
@@ -1,0 +1,60 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/eigerco/strawberry/internal/crypto"
+	"github.com/eigerco/strawberry/internal/crypto/bandersnatch"
+	"github.com/eigerco/strawberry/internal/safrole"
+	"github.com/eigerco/strawberry/internal/testutils"
+	"github.com/eigerco/strawberry/internal/validator"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateVerifyTicketProof(t *testing.T) {
+	entropy := testutils.RandomHash(t)
+	privateKey := testutils.RandomBandersnatchPrivateKey(t)
+
+	currentValidators := safrole.ValidatorsData{}
+	for i := range currentValidators {
+		currentValidators[i] = &crypto.ValidatorKey{
+			Bandersnatch: testutils.RandomBandersnatchPublicKey(t),
+		}
+	}
+
+	// Add our public key to the current validators set.
+	publicKey, err := bandersnatch.Public(privateKey)
+	require.NoError(t, err)
+	currentValidators[1] = &crypto.ValidatorKey{
+		Bandersnatch: publicKey,
+	}
+
+	state := &State{
+		EntropyPool: [4]crypto.Hash{
+			testutils.RandomHash(t),
+			testutils.RandomHash(t),
+			entropy,
+			testutils.RandomHash(t),
+		},
+		ValidatorState: validator.ValidatorState{
+			SafroleState: safrole.State{
+				NextValidators: currentValidators,
+			},
+		},
+	}
+
+	// Set the ring commitment.
+	ringCommitment, err := state.ValidatorState.SafroleState.CalculateRingCommitment()
+	require.NoError(t, err)
+	state.ValidatorState.SafroleState.RingCommitment = ringCommitment
+
+	// Create a ticket proof.
+	ticket, err := CreateTicketProof(state, privateKey, 0)
+	require.NoError(t, err)
+
+	// Verify the ticket proof.
+	outputHash, err := VerifyTicketProof(state, ticket)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, outputHash)
+}

--- a/internal/state/ticket_test.go
+++ b/internal/state/ticket_test.go
@@ -3,6 +3,7 @@ package state
 import (
 	"testing"
 
+	"github.com/eigerco/strawberry/internal/block"
 	"github.com/eigerco/strawberry/internal/crypto"
 	"github.com/eigerco/strawberry/internal/crypto/bandersnatch"
 	"github.com/eigerco/strawberry/internal/safrole"
@@ -57,4 +58,144 @@ func TestCreateVerifyTicketProof(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotEmpty(t, outputHash)
+}
+
+func TestCreateTicketProofInvalidState(t *testing.T) {
+	privateKey := testutils.RandomBandersnatchPrivateKey(t)
+
+	currentValidators := safrole.ValidatorsData{}
+	for i := range currentValidators {
+		currentValidators[i] = &crypto.ValidatorKey{
+			// Invalid public keys. Can't be all zero'd out.
+			Bandersnatch: crypto.BandersnatchPublicKey{},
+		}
+	}
+
+	state := &State{
+		EntropyPool: [4]crypto.Hash{
+			testutils.RandomHash(t),
+			testutils.RandomHash(t),
+			testutils.RandomHash(t),
+			testutils.RandomHash(t),
+		},
+		ValidatorState: validator.ValidatorState{
+			SafroleState: safrole.State{
+				NextValidators: currentValidators,
+			},
+		},
+	}
+
+	_, err := CreateTicketProof(state, privateKey, 0)
+	require.Error(t, err)
+}
+
+func TestCreateTicketProofInvalidPrivateKey(t *testing.T) {
+	privateKey := crypto.BandersnatchPrivateKey{}
+
+	currentValidators := safrole.ValidatorsData{}
+	for i := range currentValidators {
+		currentValidators[i] = &crypto.ValidatorKey{
+			Bandersnatch: testutils.RandomBandersnatchPublicKey(t),
+		}
+	}
+
+	state := &State{
+		EntropyPool: [4]crypto.Hash{
+			testutils.RandomHash(t),
+			testutils.RandomHash(t),
+			testutils.RandomHash(t),
+			testutils.RandomHash(t),
+		},
+		ValidatorState: validator.ValidatorState{
+			SafroleState: safrole.State{
+				NextValidators: currentValidators,
+			},
+		},
+	}
+
+	_, err := CreateTicketProof(state, privateKey, 0)
+	require.Error(t, err)
+}
+
+func TestVerifyTicketProofInvalidState(t *testing.T) {
+	entropy := testutils.RandomHash(t)
+	privateKey := testutils.RandomBandersnatchPrivateKey(t)
+
+	currentValidators := safrole.ValidatorsData{}
+	for i := range currentValidators {
+		currentValidators[i] = &crypto.ValidatorKey{
+			Bandersnatch: testutils.RandomBandersnatchPublicKey(t),
+		}
+	}
+
+	// Add our public key to the current validators set.
+	publicKey, err := bandersnatch.Public(privateKey)
+	require.NoError(t, err)
+	currentValidators[1] = &crypto.ValidatorKey{
+		Bandersnatch: publicKey,
+	}
+
+	state := &State{
+		EntropyPool: [4]crypto.Hash{
+			testutils.RandomHash(t),
+			testutils.RandomHash(t),
+			entropy,
+			testutils.RandomHash(t),
+		},
+		ValidatorState: validator.ValidatorState{
+			SafroleState: safrole.State{
+				NextValidators: currentValidators,
+			},
+		},
+	}
+
+	// Create a ticket proof.
+	ticket, err := CreateTicketProof(state, privateKey, 0)
+	require.NoError(t, err)
+
+	// Create invalid validators.
+	incorrectValidators := safrole.ValidatorsData{}
+	for i := range incorrectValidators {
+		incorrectValidators[i] = &crypto.ValidatorKey{
+			// Invalid public keys. Can't be all zero'd out.
+			Bandersnatch: crypto.BandersnatchPublicKey{},
+		}
+	}
+	state.ValidatorState.SafroleState.NextValidators = incorrectValidators
+	// Set an empty ring commitment.
+	state.ValidatorState.SafroleState.RingCommitment = crypto.RingCommitment{}
+
+	_, err = VerifyTicketProof(state, ticket)
+	require.Error(t, err)
+}
+
+func TestVerifyTicketProofInvalidTicketProof(t *testing.T) {
+	currentValidators := safrole.ValidatorsData{}
+	for i := range currentValidators {
+		currentValidators[i] = &crypto.ValidatorKey{
+			Bandersnatch: testutils.RandomBandersnatchPublicKey(t),
+		}
+	}
+
+	state := &State{
+		EntropyPool: [4]crypto.Hash{
+			testutils.RandomHash(t),
+			testutils.RandomHash(t),
+			testutils.RandomHash(t),
+			testutils.RandomHash(t),
+		},
+		ValidatorState: validator.ValidatorState{
+			SafroleState: safrole.State{
+				NextValidators: currentValidators,
+			},
+		},
+	}
+
+	// Set the ring commitment.
+	ringCommitment, err := state.ValidatorState.SafroleState.CalculateRingCommitment()
+	require.NoError(t, err)
+	state.ValidatorState.SafroleState.RingCommitment = ringCommitment
+
+	_, err = VerifyTicketProof(state, block.TicketProof{})
+	require.Error(t, err)
 }


### PR DESCRIPTION
Also:
- Add functions to Create and Verify ticket proofs.
- Add method to get a RingProver from the SAFROLE state. Used to generate ring signatures for ticket proof submission.
- Rearrange SAFROLE state transition code given issues found during simulation. The accumulator needed to be reset before new tickets are added.

Closes #285 