### PR TITLE
Update erasure coding constants

### DIFF
--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -17,6 +17,7 @@ const (
 	SizeOfSegment                                = NumberOfErasureCodecPiecesInSegment * ErasureCodingChunkSize // WG = WP*WE = 4104: The size of a segment in octets.
 	MaxWorkPackageSize                           = 12 * 1 << 20                                                 // WB = 12 MB: The maximum size of an encoded work-package in octets (including extrinsic data and import implications).
 	NumberOfErasureCodecPiecesInSegment          = 6                                                            // WP = 6: The number of erasure-coded pieces in a segment.
+	ErasureCodingOriginalShards                  = 342                                                          // The number of original shards.
 	ErasureCodingChunkSize                       = 684                                                          // WE = 684: The basic size of erasure-coded pieces in octets.
 	MaxAllocatedGasAccumulation                  = 10_000_000                                                   // GA: The gas allocated to invoke a work-report’s Accumulation logic.
 	MaxAllocatedGasIsAuthorized                  = 50_000_000                                                   // GI: The gas allocated to invoke a work-package’s Is-Authorized logic.

--- a/internal/common/constants_integration.go
+++ b/internal/common/constants_integration.go
@@ -16,8 +16,9 @@ const (
 	MaxHistoricalTimeslotsForPreimageMeta        = 3
 	SizeOfSegment                                = NumberOfErasureCodecPiecesInSegment * ErasureCodingChunkSize
 	MaxWorkPackageSize                           = 12 * 1 << 20
-	NumberOfErasureCodecPiecesInSegment          = 6
-	ErasureCodingChunkSize                       = 684
+	NumberOfErasureCodecPiecesInSegment          = 1026
+	ErasureCodingOriginalShards                  = 2
+	ErasureCodingChunkSize                       = 4
 	MaxAllocatedGasAccumulation                  = 10_000_000
 	MaxAllocatedGasIsAuthorized                  = 50_000_000
 	WorkReportMaxSumOfDependencies               = 8

--- a/internal/erasurecoding/erasurecoding.go
+++ b/internal/erasurecoding/erasurecoding.go
@@ -11,7 +11,7 @@ import (
 // These parameters allow data to be retrieved even when only 1/3 of the
 // validators are available.
 const (
-	OriginalShards = 342                                            // Number of original data shards.
+	OriginalShards = common.ErasureCodingOriginalShards             // Number of original data shards.
 	RecoveryShards = common.NumberOfValidators - OriginalShards     // Number of recovery data shards.
 	ChunkShardSize = common.ErasureCodingChunkSize / OriginalShards // In bytes.
 )


### PR DESCRIPTION
- Add integration (tiny) constants.
- Add no original shards constant.
- Fix the erasure coding chunk size and number of erasure codec pieces as constants in line with GP values.