### PR TITLE
ValidatorStatistics -> ActivityStatistics

### DIFF
--- a/internal/state/merkle/helpers_test.go
+++ b/internal/state/merkle/helpers_test.go
@@ -236,10 +236,10 @@ func RandomValidatorStatistics() validator.ValidatorStatistics {
 	}
 }
 
-func RandomValidatorStatisticsState() validator.ValidatorStatisticsState {
-	return validator.ValidatorStatisticsState{
-		[common.NumberOfValidators]validator.ValidatorStatistics{RandomValidatorStatistics(), RandomValidatorStatistics()},
-		[common.NumberOfValidators]validator.ValidatorStatistics{RandomValidatorStatistics(), RandomValidatorStatistics()},
+func RandomValidatorStatisticsState() validator.ActivityStatisticsState {
+	return validator.ActivityStatisticsState{
+		ValidatorsCurrent: [common.NumberOfValidators]validator.ValidatorStatistics{RandomValidatorStatistics(), RandomValidatorStatistics()},
+		ValidatorsLast:    [common.NumberOfValidators]validator.ValidatorStatistics{RandomValidatorStatistics(), RandomValidatorStatistics()},
 	}
 }
 
@@ -298,7 +298,7 @@ func RandomState(t *testing.T) state.State {
 		RecentBlocks:             []state.BlockState{RandomBlockState(t)},
 		TimeslotIndex:            testutils.RandomTimeslot(),
 		PastJudgements:           RandomJudgements(t),
-		ValidatorStatistics:      RandomValidatorStatisticsState(),
+		ActivityStatistics:       RandomValidatorStatisticsState(),
 		AccumulationQueue:        RandomAccumulationQueue(t),
 		AccumulationHistory:      RandomAccumulationHistory(t),
 	}
@@ -333,7 +333,7 @@ func DeserializeState(serializedState map[crypto.Hash][]byte) (state.State, erro
 		{10, &deserializedState.CoreAssignments},
 		{11, &deserializedState.TimeslotIndex},
 		{12, &deserializedState.PrivilegedServices},
-		{13, &deserializedState.ValidatorStatistics},
+		{13, &deserializedState.ActivityStatistics},
 		{14, &deserializedState.AccumulationQueue},
 		{15, &deserializedState.AccumulationHistory},
 	}

--- a/internal/state/merkle/serialization.go
+++ b/internal/state/merkle/serialization.go
@@ -41,7 +41,7 @@ func SerializeState(state state.State) (map[crypto.Hash][]byte, error) {
 		{10, state.CoreAssignments},
 		{11, state.TimeslotIndex},
 		{12, state.PrivilegedServices},
-		{13, state.ValidatorStatistics},
+		{13, state.ActivityStatistics},
 		{14, state.AccumulationQueue},
 		{15, state.AccumulationHistory},
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -8,17 +8,17 @@ import (
 
 // State represents the complete state of the system
 type State struct {
-	Services                 service.ServiceState               // Service accounts mapping (δ)
-	PrivilegedServices       service.PrivilegedServices         // Privileged services (𝝌): services which hold some privileged status.
-	ValidatorState           validator.ValidatorState           // Validator related state (κ, λ, ι, γ)
-	EntropyPool              EntropyPool                        // On-chain Entropy pool (η): pool of entropy accumulators (also called randomness accumulators).
-	CoreAuthorizersPool      CoreAuthorizersPool                // Core authorizers pool (α): authorization requirement which work done on that core must satisfy at the time of being reported on-chain.
-	PendingAuthorizersQueues PendingAuthorizersQueues           // Pending Core authorizers queue (φ): the queue which fills core authorizations.
-	CoreAssignments          CoreAssignments                    // Core assignments (ρ): each of the cores’ currently assigned report, the availability of whose work-package must yet be assured by a super-majority of validators. This is what each core is up to right now, tracks the work-reports which have been reported but not yet accumulated, the identities of the guarantors who reported them and the time at which it was reported.
-	RecentBlocks             []BlockState                       // Block-related state (β): details of the most recent blocks. TODO: Maximum length: MaxRecentBlocks
-	TimeslotIndex            jamtime.Timeslot                   // Time-related state (τ): the most recent block’s slot index.
-	PastJudgements           Judgements                         // PastJudgements (ψ) - past judgements on work-reports and validators.
-	ValidatorStatistics      validator.ValidatorStatisticsState // Validator statistics (π) - The activity statistics for the validators.
-	AccumulationQueue        AccumulationQueue                  // Accumulation Queue (ϑ) - ready (i.e. available and/or audited) but not-yet-accumulated work-reports. Each of these were made available at most one epoch ago but have or had unfulfilled dependencies.
-	AccumulationHistory      AccumulationHistory                // Accumulation history (ξ) - history of what has been accumulated for an epoch worth of work-reports. Mapping of work-package hash to segment-root.
+	Services                 service.ServiceState              // Service accounts mapping (δ)
+	PrivilegedServices       service.PrivilegedServices        // Privileged services (𝝌): services which hold some privileged status.
+	ValidatorState           validator.ValidatorState          // Validator related state (κ, λ, ι, γ)
+	EntropyPool              EntropyPool                       // On-chain Entropy pool (η): pool of entropy accumulators (also called randomness accumulators).
+	CoreAuthorizersPool      CoreAuthorizersPool               // Core authorizers pool (α): authorization requirement which work done on that core must satisfy at the time of being reported on-chain.
+	PendingAuthorizersQueues PendingAuthorizersQueues          // Pending Core authorizers queue (φ): the queue which fills core authorizations.
+	CoreAssignments          CoreAssignments                   // Core assignments (ρ): each of the cores’ currently assigned report, the availability of whose work-package must yet be assured by a super-majority of validators. This is what each core is up to right now, tracks the work-reports which have been reported but not yet accumulated, the identities of the guarantors who reported them and the time at which it was reported.
+	RecentBlocks             []BlockState                      // Block-related state (β): details of the most recent blocks. TODO: Maximum length: MaxRecentBlocks
+	TimeslotIndex            jamtime.Timeslot                  // Time-related state (τ): the most recent block’s slot index.
+	PastJudgements           Judgements                        // PastJudgements (ψ) - past judgements on work-reports and validators.
+	ActivityStatistics       validator.ActivityStatisticsState // Validator statistics (π) - The activity statistics for the validators.
+	AccumulationQueue        AccumulationQueue                 // Accumulation Queue (ϑ) - ready (i.e. available and/or audited) but not-yet-accumulated work-reports. Each of these were made available at most one epoch ago but have or had unfulfilled dependencies.
+	AccumulationHistory      AccumulationHistory               // Accumulation history (ξ) - history of what has been accumulated for an epoch worth of work-reports. Mapping of work-package hash to segment-root.
 }

--- a/tests/integration/statistics_test.go
+++ b/tests/integration/statistics_test.go
@@ -36,8 +36,8 @@ type StatisticsState struct {
 }
 
 type Pi struct {
-	Current []PiData `json:"current"`
-	Last    []PiData `json:"last"`
+	ValsCurrent []PiData `json:"current"`
+	ValsLast    []PiData `json:"last"`
 }
 
 type PiData struct {
@@ -132,8 +132,8 @@ func mapStatisticsInput(s StatisticsInput) block.Block {
 
 func mapStatisticsState(s StatisticsState) state.State {
 	return state.State{
-		ValidatorStatistics: [2][common.NumberOfValidators]validator.ValidatorStatistics{
-			[common.NumberOfValidators]validator.ValidatorStatistics(mapSlice(s.Pi.Last, func(pi PiData) validator.ValidatorStatistics {
+		ActivityStatistics: validator.ActivityStatisticsState{
+			ValidatorsLast: [common.NumberOfValidators]validator.ValidatorStatistics(mapSlice(s.Pi.ValsLast, func(pi PiData) validator.ValidatorStatistics {
 				return validator.ValidatorStatistics{
 					NumOfBlocks:                 pi.Blocks,
 					NumOfTickets:                pi.Tickets,
@@ -143,7 +143,7 @@ func mapStatisticsState(s StatisticsState) state.State {
 					NumOfAvailabilityAssurances: pi.Assurances,
 				}
 			})),
-			[common.NumberOfValidators]validator.ValidatorStatistics(mapSlice(s.Pi.Current, func(pi PiData) validator.ValidatorStatistics {
+			ValidatorsCurrent: [common.NumberOfValidators]validator.ValidatorStatistics(mapSlice(s.Pi.ValsCurrent, func(pi PiData) validator.ValidatorStatistics {
 				return validator.ValidatorStatistics{
 					NumOfBlocks:                 pi.Blocks,
 					NumOfTickets:                pi.Tickets,
@@ -190,7 +190,7 @@ func TestStatistics(t *testing.T) {
 				reporters.Add(mustStringToHex(reporter))
 			}
 
-			preState.ValidatorStatistics = statetransition.CalculateNewValidatorStatistics(newBlock, preState.TimeslotIndex, preState.ValidatorStatistics, reporters, preState.ValidatorState.CurrentValidators)
+			preState.ActivityStatistics = statetransition.CalculateNewActivityStatistics(newBlock, preState.TimeslotIndex, preState.ActivityStatistics, reporters, preState.ValidatorState.CurrentValidators)
 
 			postState := mapStatisticsState(tc.PostState)
 


### PR DESCRIPTION
Add initial ActivityStatistics structs which replace ValidatorStatistics.

The primary purpose of this commit is to add enough of ActivityStatistics to allow work on JSON encoding/decoding the state to continue which requires these structs to exist.

The logic for computing ValidatorStatistics hasn't really changed. There are no test vectors for the new core statistics and service statistics. It seemed prudent to rather wait for vectors to be available before starting work on the logic to compute them.

An attempt was made to update the test vectors to the latest despite the above, but the changes to these test vectors affect other test vectors too, and hence it makes more sense to update all the others with the same minor changes.