### PR TITLE
Make the authorizers pool an array of arrays

### DIFF
--- a/internal/state/merkle/helpers_test.go
+++ b/internal/state/merkle/helpers_test.go
@@ -90,8 +90,8 @@ func RandomEntropyPool(t *testing.T) state.EntropyPool {
 func RandomCoreAuthorizersPool(t *testing.T) state.CoreAuthorizersPool {
 	var pool state.CoreAuthorizersPool
 	for i := range pool {
-		for range state.MaxAuthorizersPerCore {
-			pool[i] = append(pool[i], testutils.RandomHash(t))
+		for j := range state.MaxAuthorizersPerCore {
+			pool[i][j] = testutils.RandomHash(t)
 		}
 	}
 	return pool

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -29,7 +29,8 @@ type PendingAuthorizersQueue [PendingAuthorizersQueueSize]crypto.Hash
 type PendingAuthorizersQueues [common.TotalNumberOfCores]PendingAuthorizersQueue
 
 type EntropyPool [EntropyPoolSize]crypto.Hash
-type CoreAuthorizersPool [common.TotalNumberOfCores][]crypto.Hash // TODO: Maximum length per core: MaxAuthorizersPerCore
+
+type CoreAuthorizersPool [common.TotalNumberOfCores][MaxAuthorizersPerCore]crypto.Hash
 
 type WorkReportWithUnAccumulatedDependencies struct {
 	WorkReport   block.WorkReport

--- a/internal/statetransition/state_transition.go
+++ b/internal/statetransition/state_transition.go
@@ -727,7 +727,7 @@ func CalculateNewCoreAuthorizations(header block.Header, guarantees block.Guaran
 	for c := uint16(0); c < common.TotalNumberOfCores; c++ {
 		// Start with the existing authorizations for this core
 		newAuths := make([]crypto.Hash, len(currentAuthorizations[c]))
-		copy(newAuths, currentAuthorizations[c])
+		copy(newAuths, currentAuthorizations[c][:])
 
 		// Track whether a guarantee's authorizer removal has occurred
 		guaranteeAuthorizerRemoved := false
@@ -758,7 +758,7 @@ func CalculateNewCoreAuthorizations(header block.Header, guarantees block.Guaran
 		}
 
 		// Store the new authorizations for this core
-		newCoreAuthorizations[c] = newAuths
+		copy(newCoreAuthorizations[c][:], newAuths)
 	}
 
 	return newCoreAuthorizations

--- a/internal/work/results/guarantee_test.go
+++ b/internal/work/results/guarantee_test.go
@@ -2,9 +2,10 @@ package results
 
 import (
 	"crypto/ed25519"
+	"testing"
+
 	"github.com/eigerco/strawberry/internal/state"
 	"github.com/eigerco/strawberry/internal/testutils"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,16 +14,6 @@ import (
 	"github.com/eigerco/strawberry/internal/crypto"
 	"github.com/eigerco/strawberry/internal/work"
 )
-
-func EmptyCoreAuthorizersPool() state.CoreAuthorizersPool {
-	var pool state.CoreAuthorizersPool
-	for i := range pool {
-		for range state.MaxAuthorizersPerCore {
-			pool[i] = append(pool[i], crypto.Hash{})
-		}
-	}
-	return pool
-}
 
 func TestNewGuaranteeManager(t *testing.T) {
 	t.Run("valid computation", func(t *testing.T) {
@@ -58,7 +49,10 @@ func TestProcessWorkPackageGuarantee(t *testing.T) {
 		exHash: exData,
 	}
 
+	authCodeHash := testutils.RandomHash(t)
+
 	validPkg := work.Package{
+		AuthCodeHash: authCodeHash,
 		WorkItems: []work.Item{
 			{
 				ImportedSegments: []work.ImportedSegment{
@@ -95,7 +89,7 @@ func TestProcessWorkPackageGuarantee(t *testing.T) {
 			coreIndex:    1,
 			guarantorIdx: 1,
 			privKey:      privateKey1,
-			authPool:     EmptyCoreAuthorizersPool(),
+			authPool:     state.CoreAuthorizersPool{},
 			extraCreds: []block.CredentialSignature{
 				{ValidatorIndex: 2, Signature: crypto.Ed25519Signature{1}}, // Add a second credential
 			},
@@ -106,7 +100,7 @@ func TestProcessWorkPackageGuarantee(t *testing.T) {
 			coreIndex:    1,
 			guarantorIdx: 1,
 			privKey:      privateKey1,
-			authPool:     EmptyCoreAuthorizersPool(),
+			authPool:     state.CoreAuthorizersPool{},
 			expectError:  true,
 			errorMessage: "failed to generate guarantee",
 		},
@@ -116,7 +110,7 @@ func TestProcessWorkPackageGuarantee(t *testing.T) {
 			coreIndex:    1,
 			guarantorIdx: 1,
 			privKey:      privateKey1,
-			authPool:     state.CoreAuthorizersPool{}, // Empty pool
+			authPool:     state.CoreAuthorizersPool{},
 			expectError:  true,
 			errorMessage: "work package not authorized for this core",
 		},

--- a/tests/integration/authorizations_test.go
+++ b/tests/integration/authorizations_test.go
@@ -5,12 +5,13 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/eigerco/strawberry/internal/common"
-	"github.com/eigerco/strawberry/internal/crypto"
 	"io"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/eigerco/strawberry/internal/common"
+	"github.com/eigerco/strawberry/internal/crypto"
 
 	"github.com/eigerco/strawberry/internal/block"
 	"github.com/eigerco/strawberry/internal/jamtime"
@@ -75,7 +76,6 @@ func mapAuthState(s AuthState) state.State {
 		if i >= int(common.TotalNumberOfCores) {
 			break
 		}
-		authPools[i] = make([]crypto.Hash, len(pool))
 		for j, hash := range pool {
 			authPools[i][j] = crypto.Hash(mustStringToHex(hash))
 		}

--- a/tests/integration/reports_test.go
+++ b/tests/integration/reports_test.go
@@ -485,7 +485,6 @@ func mapAuthPools(pools [][]string) state.CoreAuthorizersPool {
 			break
 		}
 
-		result[i] = make([]crypto.Hash, len(pool))
 		for j, hash := range pool {
 			result[i][j] = crypto.Hash(mustStringToHex(hash))
 		}


### PR DESCRIPTION
The authorizers pool should be a 2d array of [total cores][max authorizers per core] instead of [total cores][]. This corrects state serialization since by default it would be an empty pool of max authorizers per core hashes per core, zeroed out and with a slice it would be simply be an empty slice of hashes per core.

- Update logic and tests to support this change.
- Fix a broken guarantees test which was incorrectly doing an AuthHash check.