### PR TITLE
Add fetch state trie range

### DIFF
--- a/internal/store/trie.go
+++ b/internal/store/trie.go
@@ -279,267 +279,275 @@ func (t *Trie) deleteNode(hash crypto.Hash, forceDelete bool) error {
 	return nil
 }
 
+// KeyValuePair represents a single key-value pair from the trie
+type KeyValuePair struct {
+    Key   [31]byte
+    Value []byte
+}
+
 // TrieRangeResult represents the result of a trie range query
 type TrieRangeResult struct {
-	Keys          [][31]byte  // The keys in the range
-	Values        [][]byte    // The values corresponding to the keys
-	BoundaryNodes []trie.Node // Boundary nodes covering the paths from root to the edges
+    Pairs         []KeyValuePair // The key-value pairs in the range
+    BoundaryNodes []trie.Node    // Boundary nodes covering the paths from root to the edges
 }
 
 // FetchStateTrieRange retrieves a range of key-value pairs from the trie starting at startKey and ending at or before endKey.
 // It also returns boundary nodes covering the paths from root to the start key and to the last key in the response.
 // The response size is limited to maxSize bytes, unless the response contains only a single key/value pair.
 func (t *Trie) FetchStateTrieRange(rootHash crypto.Hash, startKey, endKey [31]byte, maxSize uint32) (TrieRangeResult, error) {
-	// Validate maxSize
-	if maxSize == 0 {
-		return TrieRangeResult{}, errors.New("maxSize must be greater than zero")
-	}
+    // Validate maxSize
+    if maxSize == 0 {
+        return TrieRangeResult{}, errors.New("maxSize must be greater than zero")
+    }
+    
+    // Check if startKey > endKey, return empty result
+    if bytes.Compare(startKey[:], endKey[:]) > 0 {
+        return TrieRangeResult{}, nil
+    }
 
-	// Check if startKey > endKey, return empty result
-	if bytes.Compare(startKey[:], endKey[:]) > 0 {
-		return TrieRangeResult{}, nil
-	}
+    // Initialize result collections
+    pairs := make([]KeyValuePair, 0)
 
-	// Initialize result collections
-	keys := make([][31]byte, 0)
-	values := make([][]byte, 0)
+    // Map to store all nodes we encounter during traversal
+    allNodes := make(map[crypto.Hash]trie.Node)
 
-	// Map to store all nodes we encounter during traversal
-	allNodes := make(map[crypto.Hash]trie.Node)
+    // Track paths to first key and current last key (for boundary nodes)
+    var firstKeyPath []crypto.Hash
+    var lastKeyPath []crypto.Hash
+    var previousLastKeyPath []crypto.Hash // Track the previous last key path for backtracking
 
-	// Track paths to first key and current last key (for boundary nodes)
-	var firstKeyPath []crypto.Hash
-	var lastKeyPath []crypto.Hash
-	var previousLastKeyPath []crypto.Hash // Track the previous last key path for backtracking
+    // Use a stack for iterative traversal (DFS approach ensures in-order traversal)
+    type stackItem struct {
+        nodeHash crypto.Hash
+        path     []crypto.Hash // Track path from root to this node
+        depth    int
+    }
 
-	// Use a stack for iterative traversal (DFS approach ensures in-order traversal)
-	type stackItem struct {
-		nodeHash crypto.Hash
-		path     []crypto.Hash // Track path from root to this node
-		depth    int
-	}
+    stack := []stackItem{{
+        nodeHash: rootHash,
+        path:     []crypto.Hash{rootHash},
+        depth:    0,
+    }}
 
-	stack := []stackItem{{
-		nodeHash: rootHash,
-		path:     []crypto.Hash{rootHash},
-		depth:    0,
-	}}
+    for len(stack) > 0 {
+        // Pop from stack (DFS)
+        current := stack[len(stack)-1]
+        stack = stack[:len(stack)-1]
 
-	for len(stack) > 0 {
-		// Pop from stack (DFS)
-		current := stack[len(stack)-1]
-		stack = stack[:len(stack)-1]
+        // Get the current node
+        node, err := t.GetNode(current.nodeHash)
+        if err != nil {
+            return TrieRangeResult{}, fmt.Errorf("failed to get node %x: %w", current.nodeHash, err)
+        }
 
-		// Get the current node
-		node, err := t.GetNode(current.nodeHash)
-		if err != nil {
-			return TrieRangeResult{}, fmt.Errorf("failed to get node %x: %w", current.nodeHash, err)
-		}
+        // Store the node
+        allNodes[current.nodeHash] = node
 
-		// Store the node
-		allNodes[current.nodeHash] = node
+        if node.IsLeaf() {
+            leafKey, err := node.GetLeafKey()
+            if err != nil {
+                return TrieRangeResult{}, fmt.Errorf("failed to get leaf key: %w", err)
+            }
 
-		if node.IsLeaf() {
-			leafKey, err := node.GetLeafKey()
-			if err != nil {
-				return TrieRangeResult{}, fmt.Errorf("failed to get leaf key: %w", err)
-			}
+            var key31 [31]byte
+            copy(key31[:], leafKey[:31])
+            
+            // Early termination: if we've passed the end key, we can stop traversal entirely
+            // This optimization prevents unnecessary processing of keys that are out of range
+            if bytes.Compare(key31[:], endKey[:]) > 0 {
+                break
+            }
 
-			var key31 [31]byte
-			copy(key31[:], leafKey[:31])
+            // Determine if the current key is within our query range by performing lexicographical byte comparisons:
+            // 1. First check: bytes.Compare(key31[:], startKey[:]) >= 0 ensures the key is either equal to or comes after our startKey
+            //    (bytes.Compare returns -1 if key31 < startKey, 0 if equal, 1 if key31 > startKey)
+            // 2. Second check: bytes.Compare(key31[:], endKey[:]) <= 0 ensures the key is either equal to or comes before our endKey
+            // Together, these conditions verify the key falls within our inclusive range boundaries [startKey, endKey]
+            if bytes.Compare(key31[:], startKey[:]) >= 0 && bytes.Compare(key31[:], endKey[:]) <= 0 {
+                // Get the value
+                var valueData []byte
 
-			// Early termination: if we've passed the end key, we can stop
-			if bytes.Compare(key31[:], endKey[:]) > 0 {
-				break
-			}
+                if node.IsEmbeddedLeaf() {
+                    valueData, err = node.GetLeafValue()
+                    if err != nil {
+                        return TrieRangeResult{}, fmt.Errorf("failed to get embedded leaf value: %w", err)
+                    }
+                } else {
+                    valueHash, err := node.GetLeafValueHash()
+                    if err != nil {
+                        return TrieRangeResult{}, fmt.Errorf("failed to get leaf value hash: %w", err)
+                    }
+                    valueData, err = t.getValue(valueHash)
+                    if err != nil {
+                        return TrieRangeResult{}, fmt.Errorf("failed to get value for hash %x: %w", valueHash, err)
+                    }
+                }
 
-			// bytes.Compare(key31[:], startKey[:]) >= 0 ensures the key is either equal to or comes after our startKey
-			// bytes.Compare(key31[:], endKey[:]) <= 0 ensures the key is either equal to or comes before our endKey
-			// Together, these conditions verify the key falls within our inclusive range boundaries [startKey, endKey]
-			if bytes.Compare(key31[:], startKey[:]) >= 0 && bytes.Compare(key31[:], endKey[:]) <= 0 {
-				// Get the value
-				var valueData []byte
+                // Create and add the key-value pair
+                pair := KeyValuePair{
+                    Key:   key31,
+                    Value: valueData,
+                }
+                pairs = append(pairs, pair)
 
-				if node.IsEmbeddedLeaf() {
-					valueData, err = node.GetLeafValue()
-					if err != nil {
-						return TrieRangeResult{}, fmt.Errorf("failed to get embedded leaf value: %w", err)
-					}
-				} else {
-					valueHash, err := node.GetLeafValueHash()
-					if err != nil {
-						return TrieRangeResult{}, fmt.Errorf("failed to get leaf value hash: %w", err)
-					}
-					valueData, err = t.getValue(valueHash)
-					if err != nil {
-						return TrieRangeResult{}, fmt.Errorf("failed to get value for hash %x: %w", valueHash, err)
-					}
-				}
+                // Track path for boundary nodes
+                if len(pairs) == 1 {
+                    // This is the first key - save its path
+                    firstKeyPath = make([]crypto.Hash, len(current.path))
+                    copy(firstKeyPath, current.path)
+                }
 
-				// Add the key-value pair
-				keys = append(keys, key31)
-				values = append(values, valueData)
+                // Save the previous last key path before updating
+                if len(pairs) > 1 {
+                    previousLastKeyPath = make([]crypto.Hash, len(lastKeyPath))
+                    copy(previousLastKeyPath, lastKeyPath)
+                }
 
-				// Track path for boundary nodes
-				if len(keys) == 1 {
-					// This is the first key - save its path
-					firstKeyPath = make([]crypto.Hash, len(current.path))
-					copy(firstKeyPath, current.path)
-				}
+                // Always update last key path
+                lastKeyPath = make([]crypto.Hash, len(current.path))
+                copy(lastKeyPath, current.path)
 
-				// Save the previous last key path before updating
-				if len(keys) > 1 {
-					previousLastKeyPath = make([]crypto.Hash, len(lastKeyPath))
-					copy(previousLastKeyPath, lastKeyPath)
-				}
+                // Check if we've exceeded max size
+                // Calculate total response size including boundary nodes
+                tempBoundaryNodes := extractBoundaryNodes(firstKeyPath, lastKeyPath, allNodes)
+                tempSize := calculateResponseSize(pairs, tempBoundaryNodes)
 
-				// Always update last key path
-				lastKeyPath = make([]crypto.Hash, len(current.path))
-				copy(lastKeyPath, current.path)
+                // Check if adding this pair would exceed maxSize and we have more than one key
+                if tempSize > maxSize && len(pairs) > 1 {
+                    // Remove the last key-value pair we just added
+                    pairs = pairs[:len(pairs)-1]
 
-				// Check if we've exceeded max size
-				// Calculate total response size including boundary nodes
-				tempBoundaryNodes := extractBoundaryNodes(firstKeyPath, lastKeyPath, allNodes)
-				tempSize := calculateResponseSize(keys, values, tempBoundaryNodes)
+                    // Restore the previous lastKeyPath
+                    if len(previousLastKeyPath) > 0 {
+                        lastKeyPath = previousLastKeyPath
+                    } else {
+                        // If we only had one key before adding this one, then use firstKeyPath
+                        lastKeyPath = firstKeyPath
+                    }
 
-				// Check if adding this pair would exceed maxSize and we have more than one key
-				if tempSize > maxSize && len(keys) > 1 {
-					// Remove the last key-value pair we just added
-					keys = keys[:len(keys)-1]
-					values = values[:len(values)-1]
+                    // Break out of the loop - we've hit our size limit
+                    break
+                }
+            }
 
-					// Restore the previous lastKeyPath
-					if len(previousLastKeyPath) > 0 {
-						lastKeyPath = previousLastKeyPath
-					} else {
-						// If we only had one key before adding this one, then use firstKeyPath
-						lastKeyPath = firstKeyPath
-					}
+            continue
+        }
 
-					// Break out of the loop - we've hit our size limit
-					break
-				}
-			}
+        // For branch nodes
+        leftHash, rightHash, err := node.GetBranchHashes()
+        if err != nil {
+            return TrieRangeResult{}, fmt.Errorf("failed to get branch hashes: %w", err)
+        }
 
-			continue
-		}
+        // Process right child first (will be processed after left since we're using a stack)
+        if rightHash != (crypto.Hash{}) {
+            rightPath := make([]crypto.Hash, len(current.path)+1)
+            copy(rightPath, current.path)
+            rightPath[len(current.path)] = rightHash
 
-		// For branch nodes
-		leftHash, rightHash, err := node.GetBranchHashes()
-		if err != nil {
-			return TrieRangeResult{}, fmt.Errorf("failed to get branch hashes: %w", err)
-		}
+            stack = append(stack, stackItem{
+                nodeHash: rightHash,
+                path:     rightPath,
+                depth:    current.depth + 1,
+            })
+        }
 
-		// Process right child first (will be processed after left since we're using a stack)
-		if rightHash != (crypto.Hash{}) {
-			rightPath := make([]crypto.Hash, len(current.path)+1)
-			copy(rightPath, current.path)
-			rightPath[len(current.path)] = rightHash
+        // Process left child
+        if leftHash != (crypto.Hash{}) {
+            leftPath := make([]crypto.Hash, len(current.path)+1)
+            copy(leftPath, current.path)
+            leftPath[len(current.path)] = leftHash
 
-			stack = append(stack, stackItem{
-				nodeHash: rightHash,
-				path:     rightPath,
-				depth:    current.depth + 1,
-			})
-		}
+            stack = append(stack, stackItem{
+                nodeHash: leftHash,
+                path:     leftPath,
+                depth:    current.depth + 1,
+            })
+        }
+    }
 
-		// Process left child
-		if leftHash != (crypto.Hash{}) {
-			leftPath := make([]crypto.Hash, len(current.path)+1)
-			copy(leftPath, current.path)
-			leftPath[len(current.path)] = leftHash
+    // Extract final boundary nodes
+    boundaryNodes := extractBoundaryNodes(firstKeyPath, lastKeyPath, allNodes)
 
-			stack = append(stack, stackItem{
-				nodeHash: leftHash,
-				path:     leftPath,
-				depth:    current.depth + 1,
-			})
-		}
-	}
-
-	// Extract final boundary nodes
-	boundaryNodes := extractBoundaryNodes(firstKeyPath, lastKeyPath, allNodes)
-
-	return TrieRangeResult{
-		Keys:          keys,
-		Values:        values,
-		BoundaryNodes: boundaryNodes,
-	}, nil
+    return TrieRangeResult{
+        Pairs:         pairs,
+        BoundaryNodes: boundaryNodes,
+    }, nil
 }
 
 // extractBoundaryNodes creates a slice of boundary nodes from the given paths
 func extractBoundaryNodes(firstKeyPath, lastKeyPath []crypto.Hash, allNodes map[crypto.Hash]trie.Node) []trie.Node {
-	// Use a map to eliminate duplicates
-	nodeSet := make(map[crypto.Hash]struct{})
+    // Use a map to eliminate duplicates
+    nodeSet := make(map[crypto.Hash]struct{})
 
-	// Add nodes on the path to first key
-	for _, hash := range firstKeyPath {
-		nodeSet[hash] = struct{}{}
-	}
+    // Add nodes on the path to first key
+    for _, hash := range firstKeyPath {
+        nodeSet[hash] = struct{}{}
+    }
 
-	// Add nodes on the path to last key
-	for _, hash := range lastKeyPath {
-		nodeSet[hash] = struct{}{}
-	}
+    // Add nodes on the path to last key
+    for _, hash := range lastKeyPath {
+        nodeSet[hash] = struct{}{}
+    }
 
-	// Convert the node set to a slice, maintaining parent-before-child relationship
-	// To ensure this, we process the paths level by level from root to leaf
-	var result []trie.Node
+    // Convert the node set to a slice, maintaining parent-before-child relationship
+    // To ensure this, we process the paths level by level from root to leaf
+    var result []trie.Node
 
-	// Find the max depth of either path
-	maxDepth := max(len(firstKeyPath), len(lastKeyPath))
+    // Find the max depth of either path
+    maxDepth := max(len(firstKeyPath), len(lastKeyPath))
 
-	// Process level by level - corrected for loop
-	for depth := range maxDepth {
-		// Process first path at this depth
-		if depth < len(firstKeyPath) {
-			hash := firstKeyPath[depth]
-			// Check if we've already added this node
-			if _, exists := nodeSet[hash]; exists {
-				// Add the node and remove from set
-				if node, nodeExists := allNodes[hash]; nodeExists {
-					result = append(result, node)
-				}
-				delete(nodeSet, hash)
-			}
-		}
+    // Process level by level
+    for depth := 0; depth < maxDepth; depth++ {
+        // Process first path at this depth
+        if depth < len(firstKeyPath) {
+            hash := firstKeyPath[depth]
+            // Check if we've already added this node
+            if _, exists := nodeSet[hash]; exists {
+                // Add the node and remove from set
+                if node, nodeExists := allNodes[hash]; nodeExists {
+                    result = append(result, node)
+                }
+                delete(nodeSet, hash)
+            }
+        }
 
-		// Process last path at this depth
-		if depth < len(lastKeyPath) {
-			hash := lastKeyPath[depth]
-			// Check if we've already added this node
-			if _, exists := nodeSet[hash]; exists {
-				// Add the node and remove from set
-				if node, nodeExists := allNodes[hash]; nodeExists {
-					result = append(result, node)
-				}
-				delete(nodeSet, hash)
-			}
-		}
-	}
+        // Process last path at this depth
+        if depth < len(lastKeyPath) {
+            hash := lastKeyPath[depth]
+            // Check if we've already added this node
+            if _, exists := nodeSet[hash]; exists {
+                // Add the node and remove from set
+                if node, nodeExists := allNodes[hash]; nodeExists {
+                    result = append(result, node)
+                }
+                delete(nodeSet, hash)
+            }
+        }
+    }
 
-	return result
+    return result
 }
 
 // calculateResponseSize calculates the total size of the response in bytes, including key/value pairs and boundary nodes
-func calculateResponseSize(keys [][31]byte, values [][]byte, nodes []trie.Node) uint32 {
-	var size uint32 = 0
+func calculateResponseSize(pairs []KeyValuePair, nodes []trie.Node) uint32 {
+    var size uint32 = 0
 
-	// Size of the boundary nodes
-	// Add 4 bytes for the length prefix of the nodes array
-	size += 4 // Array length prefix
-	for _, node := range nodes {
-		size += uint32(len(node))
-	}
+    // Size of the boundary nodes
+    // Add 4 bytes for the length prefix of the nodes array
+    size += 4 // Array length prefix
+    for _, node := range nodes {
+        size += uint32(len(node))
+    }
 
-	// Size of the key/value pairs
-	// Add 4 bytes for the length prefix of the key/value array
-	size += 4 // Array length prefix
-	for i := range keys {
-		size += 31                     // Key size
-		size += 4                      // Value length prefix
-		size += uint32(len(values[i])) // Value size
-	}
+    // Size of the key/value pairs
+    // Add 4 bytes for the length prefix of the key/value array
+    size += 4 // Array length prefix
+    for _, pair := range pairs {
+        size += 31                        // Key size
+        size += 4                         // Value length prefix
+        size += uint32(len(pair.Value))   // Value size
+    }
 
-	return size
+    return size
 }

--- a/internal/store/trie.go
+++ b/internal/store/trie.go
@@ -348,6 +348,11 @@ func (t *Trie) FetchStateTrieRange(rootHash crypto.Hash, startKey, endKey [31]by
 			var key31 [31]byte
 			copy(key31[:], leafKey[:31])
 
+			// Early termination: if we've passed the end key, we can stop
+			if bytes.Compare(key31[:], endKey[:]) > 0 {
+				break
+			}
+
 			// bytes.Compare(key31[:], startKey[:]) >= 0 ensures the key is either equal to or comes after our startKey
 			// bytes.Compare(key31[:], endKey[:]) <= 0 ensures the key is either equal to or comes before our endKey
 			// Together, these conditions verify the key falls within our inclusive range boundaries [startKey, endKey]
@@ -414,11 +419,6 @@ func (t *Trie) FetchStateTrieRange(rootHash crypto.Hash, startKey, endKey [31]by
 					// Break out of the loop - we've hit our size limit
 					break
 				}
-			}
-
-			// Early termination: if we've passed the end key, we can stop
-			if bytes.Compare(key31[:], endKey[:]) > 0 {
-				break
 			}
 
 			continue

--- a/internal/store/trie.go
+++ b/internal/store/trie.go
@@ -281,273 +281,273 @@ func (t *Trie) deleteNode(hash crypto.Hash, forceDelete bool) error {
 
 // KeyValuePair represents a single key-value pair from the trie
 type KeyValuePair struct {
-    Key   [31]byte
-    Value []byte
+	Key   [31]byte
+	Value []byte
 }
 
 // TrieRangeResult represents the result of a trie range query
 type TrieRangeResult struct {
-    Pairs         []KeyValuePair // The key-value pairs in the range
-    BoundaryNodes []trie.Node    // Boundary nodes covering the paths from root to the edges
+	Pairs         []KeyValuePair // The key-value pairs in the range
+	BoundaryNodes []trie.Node    // Boundary nodes covering the paths from root to the edges
 }
 
 // FetchStateTrieRange retrieves a range of key-value pairs from the trie starting at startKey and ending at or before endKey.
 // It also returns boundary nodes covering the paths from root to the start key and to the last key in the response.
 // The response size is limited to maxSize bytes, unless the response contains only a single key/value pair.
 func (t *Trie) FetchStateTrieRange(rootHash crypto.Hash, startKey, endKey [31]byte, maxSize uint32) (TrieRangeResult, error) {
-    // Validate maxSize
-    if maxSize == 0 {
-        return TrieRangeResult{}, errors.New("maxSize must be greater than zero")
-    }
-    
-    // Check if startKey > endKey, return empty result
-    if bytes.Compare(startKey[:], endKey[:]) > 0 {
-        return TrieRangeResult{}, nil
-    }
+	// Validate maxSize
+	if maxSize == 0 {
+		return TrieRangeResult{}, errors.New("maxSize must be greater than zero")
+	}
 
-    // Initialize result collections
-    pairs := make([]KeyValuePair, 0)
+	// Check if startKey > endKey, return empty result
+	if bytes.Compare(startKey[:], endKey[:]) > 0 {
+		return TrieRangeResult{}, nil
+	}
 
-    // Map to store all nodes we encounter during traversal
-    allNodes := make(map[crypto.Hash]trie.Node)
+	// Initialize result collections
+	pairs := make([]KeyValuePair, 0)
 
-    // Track paths to first key and current last key (for boundary nodes)
-    var firstKeyPath []crypto.Hash
-    var lastKeyPath []crypto.Hash
-    var previousLastKeyPath []crypto.Hash // Track the previous last key path for backtracking
+	// Map to store all nodes we encounter during traversal
+	allNodes := make(map[crypto.Hash]trie.Node)
 
-    // Use a stack for iterative traversal (DFS approach ensures in-order traversal)
-    type stackItem struct {
-        nodeHash crypto.Hash
-        path     []crypto.Hash // Track path from root to this node
-        depth    int
-    }
+	// Track paths to first key and current last key (for boundary nodes)
+	var firstKeyPath []crypto.Hash
+	var lastKeyPath []crypto.Hash
+	var previousLastKeyPath []crypto.Hash // Track the previous last key path for backtracking
 
-    stack := []stackItem{{
-        nodeHash: rootHash,
-        path:     []crypto.Hash{rootHash},
-        depth:    0,
-    }}
+	// Use a stack for iterative traversal (DFS approach ensures in-order traversal)
+	type stackItem struct {
+		nodeHash crypto.Hash
+		path     []crypto.Hash // Track path from root to this node
+		depth    int
+	}
 
-    for len(stack) > 0 {
-        // Pop from stack (DFS)
-        current := stack[len(stack)-1]
-        stack = stack[:len(stack)-1]
+	stack := []stackItem{{
+		nodeHash: rootHash,
+		path:     []crypto.Hash{rootHash},
+		depth:    0,
+	}}
 
-        // Get the current node
-        node, err := t.GetNode(current.nodeHash)
-        if err != nil {
-            return TrieRangeResult{}, fmt.Errorf("failed to get node %x: %w", current.nodeHash, err)
-        }
+	for len(stack) > 0 {
+		// Pop from stack (DFS)
+		current := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
 
-        // Store the node
-        allNodes[current.nodeHash] = node
+		// Get the current node
+		node, err := t.GetNode(current.nodeHash)
+		if err != nil {
+			return TrieRangeResult{}, fmt.Errorf("failed to get node %x: %w", current.nodeHash, err)
+		}
 
-        if node.IsLeaf() {
-            leafKey, err := node.GetLeafKey()
-            if err != nil {
-                return TrieRangeResult{}, fmt.Errorf("failed to get leaf key: %w", err)
-            }
+		// Store the node
+		allNodes[current.nodeHash] = node
 
-            var key31 [31]byte
-            copy(key31[:], leafKey[:31])
-            
-            // Early termination: if we've passed the end key, we can stop traversal entirely
-            // This optimization prevents unnecessary processing of keys that are out of range
-            if bytes.Compare(key31[:], endKey[:]) > 0 {
-                break
-            }
+		if node.IsLeaf() {
+			leafKey, err := node.GetLeafKey()
+			if err != nil {
+				return TrieRangeResult{}, fmt.Errorf("failed to get leaf key: %w", err)
+			}
 
-            // Determine if the current key is within our query range by performing lexicographical byte comparisons:
-            // 1. First check: bytes.Compare(key31[:], startKey[:]) >= 0 ensures the key is either equal to or comes after our startKey
-            //    (bytes.Compare returns -1 if key31 < startKey, 0 if equal, 1 if key31 > startKey)
-            // 2. Second check: bytes.Compare(key31[:], endKey[:]) <= 0 ensures the key is either equal to or comes before our endKey
-            // Together, these conditions verify the key falls within our inclusive range boundaries [startKey, endKey]
-            if bytes.Compare(key31[:], startKey[:]) >= 0 && bytes.Compare(key31[:], endKey[:]) <= 0 {
-                // Get the value
-                var valueData []byte
+			var key31 [31]byte
+			copy(key31[:], leafKey[:31])
 
-                if node.IsEmbeddedLeaf() {
-                    valueData, err = node.GetLeafValue()
-                    if err != nil {
-                        return TrieRangeResult{}, fmt.Errorf("failed to get embedded leaf value: %w", err)
-                    }
-                } else {
-                    valueHash, err := node.GetLeafValueHash()
-                    if err != nil {
-                        return TrieRangeResult{}, fmt.Errorf("failed to get leaf value hash: %w", err)
-                    }
-                    valueData, err = t.getValue(valueHash)
-                    if err != nil {
-                        return TrieRangeResult{}, fmt.Errorf("failed to get value for hash %x: %w", valueHash, err)
-                    }
-                }
+			// Early termination: if we've passed the end key, we can stop traversal entirely
+			// This optimization prevents unnecessary processing of keys that are out of range
+			if bytes.Compare(key31[:], endKey[:]) > 0 {
+				break
+			}
 
-                // Create and add the key-value pair
-                pair := KeyValuePair{
-                    Key:   key31,
-                    Value: valueData,
-                }
-                pairs = append(pairs, pair)
+			// Determine if the current key is within our query range by performing lexicographical byte comparisons:
+			// 1. First check: bytes.Compare(key31[:], startKey[:]) >= 0 ensures the key is either equal to or comes after our startKey
+			//    (bytes.Compare returns -1 if key31 < startKey, 0 if equal, 1 if key31 > startKey)
+			// 2. Second check: bytes.Compare(key31[:], endKey[:]) <= 0 ensures the key is either equal to or comes before our endKey
+			// Together, these conditions verify the key falls within our inclusive range boundaries [startKey, endKey]
+			if bytes.Compare(key31[:], startKey[:]) >= 0 && bytes.Compare(key31[:], endKey[:]) <= 0 {
+				// Get the value
+				var valueData []byte
 
-                // Track path for boundary nodes
-                if len(pairs) == 1 {
-                    // This is the first key - save its path
-                    firstKeyPath = make([]crypto.Hash, len(current.path))
-                    copy(firstKeyPath, current.path)
-                }
+				if node.IsEmbeddedLeaf() {
+					valueData, err = node.GetLeafValue()
+					if err != nil {
+						return TrieRangeResult{}, fmt.Errorf("failed to get embedded leaf value: %w", err)
+					}
+				} else {
+					valueHash, err := node.GetLeafValueHash()
+					if err != nil {
+						return TrieRangeResult{}, fmt.Errorf("failed to get leaf value hash: %w", err)
+					}
+					valueData, err = t.getValue(valueHash)
+					if err != nil {
+						return TrieRangeResult{}, fmt.Errorf("failed to get value for hash %x: %w", valueHash, err)
+					}
+				}
 
-                // Save the previous last key path before updating
-                if len(pairs) > 1 {
-                    previousLastKeyPath = make([]crypto.Hash, len(lastKeyPath))
-                    copy(previousLastKeyPath, lastKeyPath)
-                }
+				// Create and add the key-value pair
+				pair := KeyValuePair{
+					Key:   key31,
+					Value: valueData,
+				}
+				pairs = append(pairs, pair)
 
-                // Always update last key path
-                lastKeyPath = make([]crypto.Hash, len(current.path))
-                copy(lastKeyPath, current.path)
+				// Track path for boundary nodes
+				if len(pairs) == 1 {
+					// This is the first key - save its path
+					firstKeyPath = make([]crypto.Hash, len(current.path))
+					copy(firstKeyPath, current.path)
+				}
 
-                // Check if we've exceeded max size
-                // Calculate total response size including boundary nodes
-                tempBoundaryNodes := extractBoundaryNodes(firstKeyPath, lastKeyPath, allNodes)
-                tempSize := calculateResponseSize(pairs, tempBoundaryNodes)
+				// Save the previous last key path before updating
+				if len(pairs) > 1 {
+					previousLastKeyPath = make([]crypto.Hash, len(lastKeyPath))
+					copy(previousLastKeyPath, lastKeyPath)
+				}
 
-                // Check if adding this pair would exceed maxSize and we have more than one key
-                if tempSize > maxSize && len(pairs) > 1 {
-                    // Remove the last key-value pair we just added
-                    pairs = pairs[:len(pairs)-1]
+				// Always update last key path
+				lastKeyPath = make([]crypto.Hash, len(current.path))
+				copy(lastKeyPath, current.path)
 
-                    // Restore the previous lastKeyPath
-                    if len(previousLastKeyPath) > 0 {
-                        lastKeyPath = previousLastKeyPath
-                    } else {
-                        // If we only had one key before adding this one, then use firstKeyPath
-                        lastKeyPath = firstKeyPath
-                    }
+				// Check if we've exceeded max size
+				// Calculate total response size including boundary nodes
+				tempBoundaryNodes := extractBoundaryNodes(firstKeyPath, lastKeyPath, allNodes)
+				tempSize := calculateResponseSize(pairs, tempBoundaryNodes)
 
-                    // Break out of the loop - we've hit our size limit
-                    break
-                }
-            }
+				// Check if adding this pair would exceed maxSize and we have more than one key
+				if tempSize > maxSize && len(pairs) > 1 {
+					// Remove the last key-value pair we just added
+					pairs = pairs[:len(pairs)-1]
 
-            continue
-        }
+					// Restore the previous lastKeyPath
+					if len(previousLastKeyPath) > 0 {
+						lastKeyPath = previousLastKeyPath
+					} else {
+						// If we only had one key before adding this one, then use firstKeyPath
+						lastKeyPath = firstKeyPath
+					}
 
-        // For branch nodes
-        leftHash, rightHash, err := node.GetBranchHashes()
-        if err != nil {
-            return TrieRangeResult{}, fmt.Errorf("failed to get branch hashes: %w", err)
-        }
+					// Break out of the loop - we've hit our size limit
+					break
+				}
+			}
 
-        // Process right child first (will be processed after left since we're using a stack)
-        if rightHash != (crypto.Hash{}) {
-            rightPath := make([]crypto.Hash, len(current.path)+1)
-            copy(rightPath, current.path)
-            rightPath[len(current.path)] = rightHash
+			continue
+		}
 
-            stack = append(stack, stackItem{
-                nodeHash: rightHash,
-                path:     rightPath,
-                depth:    current.depth + 1,
-            })
-        }
+		// For branch nodes
+		leftHash, rightHash, err := node.GetBranchHashes()
+		if err != nil {
+			return TrieRangeResult{}, fmt.Errorf("failed to get branch hashes: %w", err)
+		}
 
-        // Process left child
-        if leftHash != (crypto.Hash{}) {
-            leftPath := make([]crypto.Hash, len(current.path)+1)
-            copy(leftPath, current.path)
-            leftPath[len(current.path)] = leftHash
+		// Process right child first (will be processed after left since we're using a stack)
+		if rightHash != (crypto.Hash{}) {
+			rightPath := make([]crypto.Hash, len(current.path)+1)
+			copy(rightPath, current.path)
+			rightPath[len(current.path)] = rightHash
 
-            stack = append(stack, stackItem{
-                nodeHash: leftHash,
-                path:     leftPath,
-                depth:    current.depth + 1,
-            })
-        }
-    }
+			stack = append(stack, stackItem{
+				nodeHash: rightHash,
+				path:     rightPath,
+				depth:    current.depth + 1,
+			})
+		}
 
-    // Extract final boundary nodes
-    boundaryNodes := extractBoundaryNodes(firstKeyPath, lastKeyPath, allNodes)
+		// Process left child
+		if leftHash != (crypto.Hash{}) {
+			leftPath := make([]crypto.Hash, len(current.path)+1)
+			copy(leftPath, current.path)
+			leftPath[len(current.path)] = leftHash
 
-    return TrieRangeResult{
-        Pairs:         pairs,
-        BoundaryNodes: boundaryNodes,
-    }, nil
+			stack = append(stack, stackItem{
+				nodeHash: leftHash,
+				path:     leftPath,
+				depth:    current.depth + 1,
+			})
+		}
+	}
+
+	// Extract final boundary nodes
+	boundaryNodes := extractBoundaryNodes(firstKeyPath, lastKeyPath, allNodes)
+
+	return TrieRangeResult{
+		Pairs:         pairs,
+		BoundaryNodes: boundaryNodes,
+	}, nil
 }
 
 // extractBoundaryNodes creates a slice of boundary nodes from the given paths
 func extractBoundaryNodes(firstKeyPath, lastKeyPath []crypto.Hash, allNodes map[crypto.Hash]trie.Node) []trie.Node {
-    // Use a map to eliminate duplicates
-    nodeSet := make(map[crypto.Hash]struct{})
+	// Use a map to eliminate duplicates
+	nodeSet := make(map[crypto.Hash]struct{})
 
-    // Add nodes on the path to first key
-    for _, hash := range firstKeyPath {
-        nodeSet[hash] = struct{}{}
-    }
+	// Add nodes on the path to first key
+	for _, hash := range firstKeyPath {
+		nodeSet[hash] = struct{}{}
+	}
 
-    // Add nodes on the path to last key
-    for _, hash := range lastKeyPath {
-        nodeSet[hash] = struct{}{}
-    }
+	// Add nodes on the path to last key
+	for _, hash := range lastKeyPath {
+		nodeSet[hash] = struct{}{}
+	}
 
-    // Convert the node set to a slice, maintaining parent-before-child relationship
-    // To ensure this, we process the paths level by level from root to leaf
-    var result []trie.Node
+	// Convert the node set to a slice, maintaining parent-before-child relationship
+	// To ensure this, we process the paths level by level from root to leaf
+	var result []trie.Node
 
-    // Find the max depth of either path
-    maxDepth := max(len(firstKeyPath), len(lastKeyPath))
+	// Find the max depth of either path
+	maxDepth := max(len(firstKeyPath), len(lastKeyPath))
 
-    // Process level by level
-    for depth := 0; depth < maxDepth; depth++ {
-        // Process first path at this depth
-        if depth < len(firstKeyPath) {
-            hash := firstKeyPath[depth]
-            // Check if we've already added this node
-            if _, exists := nodeSet[hash]; exists {
-                // Add the node and remove from set
-                if node, nodeExists := allNodes[hash]; nodeExists {
-                    result = append(result, node)
-                }
-                delete(nodeSet, hash)
-            }
-        }
+	// Process level by level
+	for depth := 0; depth < maxDepth; depth++ {
+		// Process first path at this depth
+		if depth < len(firstKeyPath) {
+			hash := firstKeyPath[depth]
+			// Check if we've already added this node
+			if _, exists := nodeSet[hash]; exists {
+				// Add the node and remove from set
+				if node, nodeExists := allNodes[hash]; nodeExists {
+					result = append(result, node)
+				}
+				delete(nodeSet, hash)
+			}
+		}
 
-        // Process last path at this depth
-        if depth < len(lastKeyPath) {
-            hash := lastKeyPath[depth]
-            // Check if we've already added this node
-            if _, exists := nodeSet[hash]; exists {
-                // Add the node and remove from set
-                if node, nodeExists := allNodes[hash]; nodeExists {
-                    result = append(result, node)
-                }
-                delete(nodeSet, hash)
-            }
-        }
-    }
+		// Process last path at this depth
+		if depth < len(lastKeyPath) {
+			hash := lastKeyPath[depth]
+			// Check if we've already added this node
+			if _, exists := nodeSet[hash]; exists {
+				// Add the node and remove from set
+				if node, nodeExists := allNodes[hash]; nodeExists {
+					result = append(result, node)
+				}
+				delete(nodeSet, hash)
+			}
+		}
+	}
 
-    return result
+	return result
 }
 
 // calculateResponseSize calculates the total size of the response in bytes, including key/value pairs and boundary nodes
 func calculateResponseSize(pairs []KeyValuePair, nodes []trie.Node) uint32 {
-    var size uint32 = 0
+	var size uint32 = 0
 
-    // Size of the boundary nodes
-    // Add 4 bytes for the length prefix of the nodes array
-    size += 4 // Array length prefix
-    for _, node := range nodes {
-        size += uint32(len(node))
-    }
+	// Size of the boundary nodes
+	// Add 4 bytes for the length prefix of the nodes array
+	size += 4 // Array length prefix
+	for _, node := range nodes {
+		size += uint32(len(node))
+	}
 
-    // Size of the key/value pairs
-    // Add 4 bytes for the length prefix of the key/value array
-    size += 4 // Array length prefix
-    for _, pair := range pairs {
-        size += 31                        // Key size
-        size += 4                         // Value length prefix
-        size += uint32(len(pair.Value))   // Value size
-    }
+	// Size of the key/value pairs
+	// Add 4 bytes for the length prefix of the key/value array
+	size += 4 // Array length prefix
+	for _, pair := range pairs {
+		size += 31                      // Key size
+		size += 4                       // Value length prefix
+		size += uint32(len(pair.Value)) // Value size
+	}
 
-    return size
+	return size
 }

--- a/internal/store/trie_test.go
+++ b/internal/store/trie_test.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"bytes"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/eigerco/strawberry/internal/crypto"
@@ -223,4 +225,296 @@ func TestNodeRefCountAndDelete(t *testing.T) {
 	// The left branch should no longer exist
 	_, err = tr.GetNode(leftHash)
 	require.Error(t, err, "Left branch should be deleted after both tries are removed")
+}
+
+func TestCE129GetKeyValueRange(t *testing.T) {
+	// Setup test data
+	keys, values := setupTestKeys(7)
+
+	// Setup DB and Trie
+	db, err := pebble.NewKVStore()
+	require.NoError(t, err)
+	defer func() {
+		err := db.Close()
+		require.NoError(t, err)
+	}()
+
+	tr := NewTrie(db)
+
+	// Prepare key-value pairs
+	pairs := make([][2][]byte, len(keys))
+	for i := range keys {
+		pairs[i] = [2][]byte{keys[i], values[i]}
+	}
+
+	// Merklize and commit
+	root, err := tr.MerklizeAndCommit(pairs)
+	require.NoError(t, err)
+
+	// Helper function to convert to 31-byte keys
+	toKey31 := func(b []byte) [31]byte {
+		var key [31]byte
+		copy(key[:], b[:31])
+		return key
+	}
+
+	// These are the size requirements for individual keys
+	// Used to create test cases with accurate size expectations
+	keySizes := []uint32{
+		251, // key 0
+		251, // key 1
+		315, // key 2
+		315, // key 3
+		315, // key 4
+		379, // key 5
+		379, // key 6
+	}
+
+	// Precalculated sizes for different ranges of keys
+	// Used to test boundary conditions precisely
+	sizeData := map[string]uint32{
+		"full_range": 813, // Size of all 7 keys
+		"range_0_1":  366, // Size of keys 0-1
+		"range_0_2":  545, // Size of keys 0-2
+		"range_2_4":  545, // Size of keys 2-4
+		"range_4_6":  545, // Size of keys 4-6
+		"range_3_6":  660, // Size of keys 3-6
+	}
+
+	// Comprehensive test cases with explicit boundary conditions
+	testCases := []struct {
+		name              string
+		startKey          int
+		endKey            int
+		maxSize           uint32
+		expectedPairs     int
+		shouldExceedLimit bool
+	}{
+		// Basic unlimited size test
+		// Verifies the function returns all keys when size is not a constraint
+		{
+			name:              "Full range with unlimited size",
+			startKey:          0,
+			endKey:            6,
+			maxSize:           sizeData["full_range"] + 100, // Plenty of room
+			expectedPairs:     7,
+			shouldExceedLimit: false,
+		},
+
+		// Single-item exemption
+		// Verifies that a single item is always returned even if it exceeds the size limit
+		{
+			name:              "Single key with very small size limit",
+			startKey:          2,
+			endKey:            2,
+			maxSize:           10, // Much smaller than any key
+			expectedPairs:     1,  // Should still return 1 key due to single-item exemption
+			shouldExceedLimit: true,
+		},
+
+		// Exact size for 1 key
+		// Tests the boundary condition where the size limit exactly matches 1 key
+		{
+			name:              "Exact size for 1 key",
+			startKey:          0,
+			endKey:            6,
+			maxSize:           keySizes[0],
+			expectedPairs:     1,
+			shouldExceedLimit: false,
+		},
+
+		// Just under size for 2 keys
+		// Tests that with size just below what's needed for 2 keys, only 1 is returned
+		{
+			name:              "Just below size for 2 keys",
+			startKey:          0,
+			endKey:            6,
+			maxSize:           sizeData["range_0_1"] - 1,
+			expectedPairs:     1,
+			shouldExceedLimit: false,
+		},
+
+		// Exact size for 2 keys
+		// Tests the boundary condition where the size limit exactly matches 2 keys
+		{
+			name:              "Exact size for 2 keys",
+			startKey:          0,
+			endKey:            6,
+			maxSize:           sizeData["range_0_1"],
+			expectedPairs:     2,
+			shouldExceedLimit: false,
+		},
+
+		// Just above size for 2 keys
+		// Tests that adding 1 byte above 2-key size doesn't get a 3rd key
+		{
+			name:              "Just above size for 2 keys",
+			startKey:          0,
+			endKey:            6,
+			maxSize:           sizeData["range_0_1"] + 1,
+			expectedPairs:     2,
+			shouldExceedLimit: false,
+		},
+
+		// Just below size for 3 keys
+		// Key boundary test - size limit is 1 byte less than needed for 3 keys
+		{
+			name:              "Just below size for 3 keys",
+			startKey:          0,
+			endKey:            6,
+			maxSize:           sizeData["range_0_2"] - 1,
+			expectedPairs:     2, // Should return 2 keys instead of 3
+			shouldExceedLimit: false,
+		},
+
+		// Exact size for 3 keys
+		// Tests the boundary condition where the size limit exactly matches 3 keys
+		{
+			name:              "Exact size for 3 keys",
+			startKey:          0,
+			endKey:            6,
+			maxSize:           sizeData["range_0_2"],
+			expectedPairs:     3,
+			shouldExceedLimit: false,
+		},
+
+		// Middle range exact size
+		// Tests that ranges in the middle of the key space work correctly
+		{
+			name:              "Middle range with exact size limit",
+			startKey:          2,
+			endKey:            4,
+			maxSize:           sizeData["range_2_4"],
+			expectedPairs:     3, // Should return keys 2,3,4
+			shouldExceedLimit: false,
+		},
+
+		// Middle range just below size
+		// Tests middle ranges with size constraints
+		{
+			name:              "Middle range with size limit minus 1 byte",
+			startKey:          2,
+			endKey:            4,
+			maxSize:           sizeData["range_2_4"] - 1,
+			expectedPairs:     2, // Should return 2 keys instead of 3
+			shouldExceedLimit: false,
+		},
+
+		// Right side range
+		// Tests ranges toward the end of the key space which have different structure
+		{
+			name:              "Right side range with exact size limit",
+			startKey:          3,
+			endKey:            6,
+			maxSize:           sizeData["range_3_6"],
+			expectedPairs:     4, // Should return keys 3,4,5,6
+			shouldExceedLimit: false,
+		},
+
+		// Size limit between key sizes
+		// Tests what happens when the size limit falls between exact key boundaries
+		{
+			name:              "Range with size limit between key sizes",
+			startKey:          0,
+			endKey:            6,
+			maxSize:           (keySizes[0] + sizeData["range_0_1"]) / 2,
+			expectedPairs:     1, // Should return just 1 key
+			shouldExceedLimit: false,
+		},
+
+		// Empty range
+		// Tests what happens with an empty range (start key > end key)
+		{
+			name:              "Empty range (start key > end key)",
+			startKey:          3,
+			endKey:            1,
+			maxSize:           1000,
+			expectedPairs:     0, // Should return no keys
+			shouldExceedLimit: false,
+		},
+	}
+
+	// Run all test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			startKey31 := toKey31(keys[tc.startKey])
+			endKey31 := toKey31(keys[tc.endKey])
+
+			// Run the query
+			resultKeys, resultValues, resultNodes, err := tr.FetchStateTrieRange(root, startKey31, endKey31, tc.maxSize)
+			require.NoError(t, err)
+
+			// Verify key and value counts match
+			require.Equal(t, len(resultKeys), len(resultValues), "Keys and values counts should match")
+
+			// Check count of key-value pairs
+			require.Equal(t, tc.expectedPairs, len(resultKeys),
+				"Expected %d key-value pairs", tc.expectedPairs)
+
+			// Verify keys are ordered (if there are multiple keys)
+			if len(resultKeys) > 1 {
+				for i := 1; i < len(resultKeys); i++ {
+					require.True(t, bytesLessThan(resultKeys[i-1][:], resultKeys[i][:]),
+						"Keys not in ascending order")
+				}
+			}
+
+			// Calculate the total size of the response
+			totalSize := calculateResponseSize(resultKeys, resultValues, resultNodes)
+
+			if testing.Verbose() {
+				t.Logf("Response size: %d bytes (limit: %d)", totalSize, tc.maxSize)
+			}
+
+			// Verify size constraints
+			if tc.shouldExceedLimit {
+				// Special case: single key-value pair can exceed the max size
+				require.Greater(t, totalSize, tc.maxSize,
+					"Expected size to exceed maxSize due to single-item exemption")
+			} else if len(resultKeys) > 0 {
+				// Normal case: response should not exceed max size
+				require.LessOrEqual(t, totalSize, tc.maxSize,
+					"Total size (%d) exceeds maxSize (%d)", totalSize, tc.maxSize)
+			}
+
+			// Verify boundary nodes are present and form valid paths
+			if len(resultKeys) > 0 {
+				require.NotEmpty(t, resultNodes, "Boundary nodes should not be empty when keys are returned")
+			}
+		})
+	}
+}
+
+// setupTestKeys creates test keys and values with a predictable binary trie structure
+func setupTestKeys(count int) ([][]byte, [][]byte) {
+	// Create keys with a structure that ensures a binary tree with various depths
+	// Keys are designed to create a deeper structure on the right side
+	keys := [][]byte{
+		{0x01, 0x01, 0x01}, // 0000 0001 ... - Path starts with 0 (Left branch)
+		{0x41, 0x01, 0x01}, // 0100 0001 ... - Path starts with 0 (Left branch)
+		{0x81, 0x01, 0x01}, // 1000 0001 ... - Path starts with 1 (Right branch)
+		{0xA1, 0x01, 0x01}, // 1010 0001 ... - Path starts with 1 (Right branch)
+		{0xC1, 0x01, 0x01}, // 1100 0001 ... - Path starts with 1 (Right branch)
+		{0xE1, 0x01, 0x01}, // 1110 0001 ... - Path starts with 1 (Right branch)
+		{0xFF, 0x01, 0x01}, // 1111 1111 ... - Path starts with 1 (Right branch)
+	}
+
+	// Trim or extend to the requested count
+	if len(keys) > count {
+		keys = keys[:count]
+	}
+
+	// Pad keys to full length (31 bytes for the trie)
+	for i := range keys {
+		keys[i] = append(keys[i], bytes.Repeat([]byte{0x00}, 29-len(keys[i]))...)
+	}
+
+	// Create values with known sizes
+	fixedValueSize := 16
+	values := make([][]byte, len(keys))
+	for i := range values {
+		values[i] = fmt.Appendf(nil, "Value-%d-%s", i, strings.Repeat("X", fixedValueSize-8))
+	}
+
+	return keys, values
 }

--- a/internal/store/trie_test.go
+++ b/internal/store/trie_test.go
@@ -440,27 +440,24 @@ func TestCE129GetKeyValueRange(t *testing.T) {
 			startKey31 := toKey31(keys[tc.startKey])
 			endKey31 := toKey31(keys[tc.endKey])
 
-			// Run the query - updated to use the new return type
+			// Run the query with the new return type
 			result, err := tr.FetchStateTrieRange(root, startKey31, endKey31, tc.maxSize)
 			require.NoError(t, err)
 
-			// Verify key and value counts match
-			require.Equal(t, len(result.Keys), len(result.Values), "Keys and values counts should match")
-
 			// Check count of key-value pairs
-			require.Equal(t, tc.expectedPairs, len(result.Keys),
+			require.Equal(t, tc.expectedPairs, len(result.Pairs),
 				"Expected %d key-value pairs", tc.expectedPairs)
 
 			// Verify keys are ordered (if there are multiple keys)
-			if len(result.Keys) > 1 {
-				for i := 1; i < len(result.Keys); i++ {
-					require.True(t, bytes.Compare(result.Keys[i-1][:], result.Keys[i][:]) < 0,
+			if len(result.Pairs) > 1 {
+				for i := 1; i < len(result.Pairs); i++ {
+					require.True(t, bytes.Compare(result.Pairs[i-1].Key[:], result.Pairs[i].Key[:]) < 0,
 						"Keys not in ascending order")
 				}
 			}
 
 			// Calculate the total size of the response
-			totalSize := calculateResponseSize(result.Keys, result.Values, result.BoundaryNodes)
+			totalSize := calculateResponseSize(result.Pairs, result.BoundaryNodes)
 
 			if testing.Verbose() {
 				t.Logf("Response size: %d bytes (limit: %d)", totalSize, tc.maxSize)
@@ -471,14 +468,14 @@ func TestCE129GetKeyValueRange(t *testing.T) {
 				// Special case: single key-value pair can exceed the max size
 				require.Greater(t, totalSize, tc.maxSize,
 					"Expected size to exceed maxSize due to single-item exemption")
-			} else if len(result.Keys) > 0 {
+			} else if len(result.Pairs) > 0 {
 				// Normal case: response should not exceed max size
 				require.LessOrEqual(t, totalSize, tc.maxSize,
 					"Total size (%d) exceeds maxSize (%d)", totalSize, tc.maxSize)
 			}
 
 			// Verify boundary nodes are present and form valid paths
-			if len(result.Keys) > 0 {
+			if len(result.Pairs) > 0 {
 				require.NotEmpty(t, result.BoundaryNodes, "Boundary nodes should not be empty when keys are returned")
 			}
 		})


### PR DESCRIPTION
CE129 is a protocol that handles State requests. It allows nodes to request a range of a block's posterior state between two keys with a size limit. The protocol returns:
A series of key/value pairs from the state trie
Boundary nodes to verify the returned data

The FetchStateTrieRange function implements:
Accepting the exact parameters specified in CE129 (start key, end key, max size)
Returning key/value pairs within the specified range
Providing boundary nodes covering paths from root to start key and to the last returned key
Enforcing size limits as required by the protocol

This is data part of https://github.com/eigerco/strawberry/issues/229. After this is merged, the last PR would be to request and send that data.