### PR TITLE
Use UpdateState for simulation test

### DIFF
--- a/internal/testutils/json/json.go
+++ b/internal/testutils/json/json.go
@@ -235,7 +235,7 @@ func (tk TicketsOrKeys) To() safrole.SealingKeys {
 	sealingKeys := safrole.SealingKeys{}
 
 	if len(tk.Keys) > 0 {
-		keys := make([]crypto.BandersnatchPublicKey, len(tk.Keys))
+		keys := crypto.EpochKeys{}
 		for i, keyStr := range tk.Keys {
 			keys[i] = hexToBandersnatch(keyStr)
 		}


### PR DESCRIPTION
Modify the simulation test to use the full UpdateState function.

Also:
- Use json test utils to restore the state.
- Fix  restoring sealing keys in json utils.