### PR TITLE
Update state serialization to use a 31 byte state key

### DIFF
--- a/internal/state/merkle/helpers_test.go
+++ b/internal/state/merkle/helpers_test.go
@@ -304,8 +304,8 @@ func RandomState(t *testing.T) state.State {
 	}
 }
 
-// DeserializeState deserializes the given map of crypto.Hash to byte slices into a State object. Not possible to restore the full state.
-func DeserializeState(serializedState map[crypto.Hash][]byte) (state.State, error) {
+// DeserializeState deserializes the given map of state keys to byte slices into a State object. Not possible to restore the full state.
+func DeserializeState(serializedState map[state.StateKey][]byte) (state.State, error) {
 	deserializedState := state.State{}
 
 	// Helper function to deserialize individual fields
@@ -362,7 +362,7 @@ func DeserializeState(serializedState map[crypto.Hash][]byte) (state.State, erro
 	return deserializedState, nil
 }
 
-func deserializeSafroleState(state *state.State, serializedState map[crypto.Hash][]byte) error {
+func deserializeSafroleState(state *state.State, serializedState map[state.StateKey][]byte) error {
 	stateKey := generateStateKeyBasic(4)
 	encodedSafroleState, ok := serializedState[stateKey]
 	if !ok {
@@ -380,7 +380,7 @@ func deserializeSafroleState(state *state.State, serializedState map[crypto.Hash
 	return nil
 }
 
-func deserializeJudgements(state *state.State, serializedState map[crypto.Hash][]byte) error {
+func deserializeJudgements(state *state.State, serializedState map[state.StateKey][]byte) error {
 	stateKey := generateStateKeyBasic(5)
 	encodedValue, ok := serializedState[stateKey]
 	if !ok {
@@ -406,7 +406,7 @@ func deserializeJudgements(state *state.State, serializedState map[crypto.Hash][
 	return nil
 }
 
-func deserializeServices(state *state.State, serializedState map[crypto.Hash][]byte) error {
+func deserializeServices(state *state.State, serializedState map[state.StateKey][]byte) error {
 	state.Services = make(service.ServiceState)
 
 	// Iterate over serializedState and look for service entries (identified by prefix 255)
@@ -450,12 +450,12 @@ func deserializeServices(state *state.State, serializedState map[crypto.Hash][]b
 	return nil
 }
 
-func isServiceAccountKey(stateKey crypto.Hash) bool {
+func isServiceAccountKey(stateKey state.StateKey) bool {
 	// Check if the first byte of the state key is 255 (which identifies service keys)
 	return stateKey[0] == 255
 }
 
-func extractServiceIdFromKey(stateKey crypto.Hash) (block.ServiceId, error) {
+func extractServiceIdFromKey(stateKey state.StateKey) (block.ServiceId, error) {
 	// Collect service ID bytes from positions 1,3,5,7 into a slice
 	encodedServiceId := []byte{
 		stateKey[1],

--- a/internal/state/merkle/serialization_test.go
+++ b/internal/state/merkle/serialization_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/eigerco/strawberry/internal/crypto"
 	"github.com/eigerco/strawberry/internal/safrole"
 	"github.com/eigerco/strawberry/pkg/serialization/codec/jam"
 )
@@ -100,9 +99,8 @@ func TestSerializeStateCoreAuthorizersPool(t *testing.T) {
 	require.NoError(t, err)
 
 	stateKey := generateStateKeyBasic(1)
-	hashKey := crypto.Hash(stateKey)
-	assert.Contains(t, serializedState, hashKey)
-	assert.NotEmpty(t, serializedState[hashKey])
+	assert.Contains(t, serializedState, stateKey)
+	assert.NotEmpty(t, serializedState[stateKey])
 }
 
 // TestSerializeStatePendingAuthorizersQueues checks the serialization of the PendingAuthorizersQueues field.
@@ -112,9 +110,8 @@ func TestSerializeStatePendingAuthorizersQueues(t *testing.T) {
 	require.NoError(t, err)
 
 	stateKey := generateStateKeyBasic(2)
-	hashKey := crypto.Hash(stateKey)
-	assert.Contains(t, serializedState, hashKey)
-	assert.NotEmpty(t, serializedState[hashKey])
+	assert.Contains(t, serializedState, stateKey)
+	assert.NotEmpty(t, serializedState[stateKey])
 }
 
 // TestSerializeStateRecentBlocks checks the serialization of the RecentBlocks field.
@@ -124,9 +121,8 @@ func TestSerializeStateRecentBlocks(t *testing.T) {
 	require.NoError(t, err)
 
 	stateKey := generateStateKeyBasic(3)
-	hashKey := crypto.Hash(stateKey)
-	assert.Contains(t, serializedState, hashKey)
-	assert.NotEmpty(t, serializedState[hashKey])
+	assert.Contains(t, serializedState, stateKey)
+	assert.NotEmpty(t, serializedState[stateKey])
 }
 
 // TestSerializeStateValidatorState checks the serialization of the ValidatorState fields.
@@ -136,9 +132,8 @@ func TestSerializeStateValidatorState(t *testing.T) {
 	require.NoError(t, err)
 
 	stateKey := generateStateKeyBasic(4)
-	hashKey := crypto.Hash(stateKey)
-	assert.Contains(t, serializedState, hashKey)
-	assert.NotEmpty(t, serializedState[hashKey])
+	assert.Contains(t, serializedState, stateKey)
+	assert.NotEmpty(t, serializedState[stateKey])
 }
 
 // TestSerializeStatePastJudgements checks the serialization of the PastJudgements field.
@@ -147,8 +142,7 @@ func TestSerializeStatePastJudgements(t *testing.T) {
 	serializedState, err := SerializeState(state)
 	require.NoError(t, err)
 
-	stateKey := generateStateKeyBasic(5)
-	hashKey := crypto.Hash(stateKey)
+	hashKey := generateStateKeyBasic(5)
 	assert.Contains(t, serializedState, hashKey)
 	assert.NotEmpty(t, serializedState[hashKey])
 }
@@ -160,9 +154,8 @@ func TestSerializeStateEntropyPool(t *testing.T) {
 	require.NoError(t, err)
 
 	stateKey := generateStateKeyBasic(6)
-	hashKey := crypto.Hash(stateKey)
-	assert.Contains(t, serializedState, hashKey)
-	assert.NotEmpty(t, serializedState[hashKey])
+	assert.Contains(t, serializedState, stateKey)
+	assert.NotEmpty(t, serializedState[stateKey])
 }
 
 // TestSerializeStateFutureValidators checks the serialization of the FutureValidators field.
@@ -172,9 +165,8 @@ func TestSerializeStateFutureValidators(t *testing.T) {
 	require.NoError(t, err)
 
 	stateKey := generateStateKeyBasic(7)
-	hashKey := crypto.Hash(stateKey)
-	assert.Contains(t, serializedState, hashKey)
-	assert.NotEmpty(t, serializedState[hashKey])
+	assert.Contains(t, serializedState, stateKey)
+	assert.NotEmpty(t, serializedState[stateKey])
 }
 
 // TestSerializeStateCurrentValidators checks the serialization of the CurrentValidators field.
@@ -184,9 +176,8 @@ func TestSerializeStateCurrentValidators(t *testing.T) {
 	require.NoError(t, err)
 
 	stateKey := generateStateKeyBasic(8)
-	hashKey := crypto.Hash(stateKey)
-	assert.Contains(t, serializedState, hashKey)
-	assert.NotEmpty(t, serializedState[hashKey])
+	assert.Contains(t, serializedState, stateKey)
+	assert.NotEmpty(t, serializedState[stateKey])
 }
 
 // TestSerializeStatePreviousValidators checks the serialization of the PreviousValidators field.
@@ -195,8 +186,7 @@ func TestSerializeStatePreviousValidators(t *testing.T) {
 	serializedState, err := SerializeState(state)
 	require.NoError(t, err)
 
-	stateKey := generateStateKeyBasic(9)
-	hashKey := crypto.Hash(stateKey)
+	hashKey := generateStateKeyBasic(9)
 	assert.Contains(t, serializedState, hashKey)
 	assert.NotEmpty(t, serializedState[hashKey])
 }
@@ -208,9 +198,8 @@ func TestSerializeStateCoreAssignments(t *testing.T) {
 	require.NoError(t, err)
 
 	stateKey := generateStateKeyBasic(10)
-	hashKey := crypto.Hash(stateKey)
-	assert.Contains(t, serializedState, hashKey)
-	assert.NotEmpty(t, serializedState[hashKey])
+	assert.Contains(t, serializedState, stateKey)
+	assert.NotEmpty(t, serializedState[stateKey])
 }
 
 // TestSerializeStateTimeslotIndex checks the serialization of the TimeslotIndex field.
@@ -220,9 +209,8 @@ func TestSerializeStateTimeslotIndex(t *testing.T) {
 	require.NoError(t, err)
 
 	stateKey := generateStateKeyBasic(11)
-	hashKey := crypto.Hash(stateKey)
-	assert.Contains(t, serializedState, hashKey)
-	assert.NotEmpty(t, serializedState[hashKey])
+	assert.Contains(t, serializedState, stateKey)
+	assert.NotEmpty(t, serializedState[stateKey])
 }
 
 // TestSerializeStatePrivilegedServices checks the serialization of the PrivilegedServices field.
@@ -232,9 +220,8 @@ func TestSerializeStatePrivilegedServices(t *testing.T) {
 	require.NoError(t, err)
 
 	stateKey := generateStateKeyBasic(12)
-	hashKey := crypto.Hash(stateKey)
-	assert.Contains(t, serializedState, hashKey)
-	assert.NotEmpty(t, serializedState[hashKey])
+	assert.Contains(t, serializedState, stateKey)
+	assert.NotEmpty(t, serializedState[stateKey])
 }
 
 // TestSerializeStateValidatorStatistics checks the serialization of the ValidatorStatistics field.
@@ -244,9 +231,8 @@ func TestSerializeStateValidatorStatistics(t *testing.T) {
 	require.NoError(t, err)
 
 	stateKey := generateStateKeyBasic(13)
-	hashKey := crypto.Hash(stateKey)
-	assert.Contains(t, serializedState, hashKey)
-	assert.NotEmpty(t, serializedState[hashKey])
+	assert.Contains(t, serializedState, stateKey)
+	assert.NotEmpty(t, serializedState[stateKey])
 }
 
 // TestSerializeStateAccumulatedQueue checks the serialization of the AccumulatedQueue field.
@@ -255,8 +241,7 @@ func TestSerializeStateAccumulatedQueue(t *testing.T) {
 	serializedState, err := SerializeState(state)
 	require.NoError(t, err)
 
-	stateKey := generateStateKeyBasic(14)
-	hashKey := crypto.Hash(stateKey)
+	hashKey := generateStateKeyBasic(14)
 	assert.Contains(t, serializedState, hashKey)
 	assert.NotEmpty(t, serializedState[hashKey])
 }
@@ -268,9 +253,8 @@ func TestSerializeStateAccumulatedHistory(t *testing.T) {
 	require.NoError(t, err)
 
 	stateKey := generateStateKeyBasic(15)
-	hashKey := crypto.Hash(stateKey)
-	assert.Contains(t, serializedState, hashKey)
-	assert.NotEmpty(t, serializedState[hashKey])
+	assert.Contains(t, serializedState, stateKey)
+	assert.NotEmpty(t, serializedState[stateKey])
 }
 
 // TestSerializeStateServices checks the serialization of the Services field.
@@ -280,9 +264,8 @@ func TestSerializeStateServices(t *testing.T) {
 	require.NoError(t, err)
 
 	for serviceId := range state.Services {
-		stateKey, err := generateStateKeyInterleavedBasic(255, serviceId)
+		hashKey, err := generateStateKeyInterleavedBasic(255, serviceId)
 		require.NoError(t, err)
-		hashKey := crypto.Hash(stateKey)
 		assert.Contains(t, serializedState, hashKey)
 		assert.NotEmpty(t, serializedState[hashKey])
 	}

--- a/internal/state/merkle/serialization_utils.go
+++ b/internal/state/merkle/serialization_utils.go
@@ -11,11 +11,17 @@ import (
 	"github.com/eigerco/strawberry/internal/block"
 	"github.com/eigerco/strawberry/internal/crypto"
 	"github.com/eigerco/strawberry/internal/service"
+	"github.com/eigerco/strawberry/internal/state"
 )
 
-// generateStateKeyBasic to generate state key based only on i
-func generateStateKeyBasic(i uint8) [32]byte {
-	var result [32]byte
+// The hash component of the state key constructor function.
+// See equation D.1 in the graypaper 0.6.6
+type stateConstructorHashComponent [27]byte
+
+// First arity of the stake-key constructor function
+// See equation D.1 in the graypaper 0.6.6
+func generateStateKeyBasic(i uint8) state.StateKey {
+	var result state.StateKey
 
 	// Copy i as the first byte
 	result[0] = i
@@ -24,40 +30,48 @@ func generateStateKeyBasic(i uint8) [32]byte {
 	return result
 }
 
-// generateStateKeyInterleavedBasic to generate state key based on i and s
-func generateStateKeyInterleavedBasic(i uint8, s block.ServiceId) ([32]byte, error) {
+// Second arity of the stake-key constructor function, (uint8, N_S)
+// See equation D.1 in the graypaper v0.6.6
+func generateStateKeyInterleavedBasic(i uint8, s block.ServiceId) (state.StateKey, error) {
 	encodedServiceId, err := jam.Marshal(s)
 	if err != nil {
-		return [32]byte{}, err
+		return state.StateKey{}, err
 	}
 
-	var result [32]byte
+	var result state.StateKey
 
 	// Place i as the first byte
 	result[0] = i
 
 	// Place encoded service ID bytes at positions 1,3,5,7
-	for j := 0; j < 4; j++ {
-		result[1+j*2] = encodedServiceId[j]
-	}
+	result[1] = encodedServiceId[0]
+	result[3] = encodedServiceId[1]
+	result[5] = encodedServiceId[2]
+	result[7] = encodedServiceId[3]
 
 	return result, nil
 }
 
-// Function to interleave the first 4 bytes of s and h, then append the rest of h
-func generateStateKeyInterleaved(s block.ServiceId, h [32]byte) ([32]byte, error) {
+// Last airity of the stake-key constructor function, (N_S, Y_27)
+// See equation D.1 in the graypaper v0.6.6
+func generateStateKeyInterleaved(s block.ServiceId, h stateConstructorHashComponent) (state.StateKey, error) {
 	encodedServiceId, err := jam.Marshal(s)
 	if err != nil {
-		return [32]byte{}, err
+		return state.StateKey{}, err
 	}
 
-	var result [32]byte
+	var result state.StateKey
 
 	// Interleave the first 4 bytes of encodedServiceId with the first 4 bytes of h
-	for i := 0; i < 4; i++ {
-		result[i*2] = encodedServiceId[i]
-		result[i*2+1] = h[i]
-	}
+	// Interleave bytes from encodedServiceId and h
+	result[0] = encodedServiceId[0]
+	result[1] = h[0]
+	result[2] = encodedServiceId[1]
+	result[3] = h[1]
+	result[4] = encodedServiceId[2]
+	result[5] = h[2]
+	result[6] = encodedServiceId[3]
+	result[7] = h[3]
 
 	// Append the rest of h to the result
 	copy(result[8:], h[4:])

--- a/internal/state/merkle/serialization_utils_test.go
+++ b/internal/state/merkle/serialization_utils_test.go
@@ -48,9 +48,6 @@ func TestGenerateStateKeyInterleavedBasic(t *testing.T) {
 			encodedServiceId, err := jam.Marshal(tt.serviceId)
 			require.NoError(t, err)
 
-			// Verify length is 32 bytes
-			assert.Equal(t, 32, len(stateKey), "key length should be 32 bytes")
-
 			// Verify first byte is i
 			assert.Equal(t, tt.i, stateKey[0], "first byte should be i")
 
@@ -66,13 +63,13 @@ func TestGenerateStateKeyInterleavedBasic(t *testing.T) {
 			assert.Equal(t, byte(0), stateKey[8], "zero should be at position 8")
 
 			// Verify remaining bytes are zero
-			for i := 9; i < 32; i++ {
+			for i := 9; i < 31; i++ {
 				assert.Equal(t, byte(0), stateKey[i],
 					fmt.Sprintf("byte at position %d should be zero", i))
 			}
 
 			// Verify we can extract the service ID back
-			extractedServiceId, err := extractServiceIdFromKey(crypto.Hash(stateKey))
+			extractedServiceId, err := extractServiceIdFromKey(stateKey)
 			require.NoError(t, err)
 			assert.Equal(t, tt.serviceId, extractedServiceId)
 		})
@@ -82,7 +79,7 @@ func TestGenerateStateKeyInterleavedBasic(t *testing.T) {
 // TestGenerateStateKeyInterleaved verifies that the interleaving function works as expected.
 func TestGenerateStateKeyInterleaved(t *testing.T) {
 	serviceId := block.ServiceId(1234)
-	hash := crypto.Hash{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	hash := stateConstructorHashComponent{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
 
 	// Get encoded service ID for verification
 	encodedServiceId, err := jam.Marshal(serviceId)
@@ -91,9 +88,6 @@ func TestGenerateStateKeyInterleaved(t *testing.T) {
 	// Generate the interleaved state key
 	stateKey, err := generateStateKeyInterleaved(serviceId, hash)
 	require.NoError(t, err)
-
-	// Verify the length is 32 bytes
-	assert.Equal(t, 32, len(stateKey))
 
 	// Verify that the first 8 bytes are interleaved between serviceId and hash
 	assert.Equal(t, encodedServiceId[0], stateKey[0])

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -11,6 +11,8 @@ import (
 	"github.com/eigerco/strawberry/internal/service"
 )
 
+type StateKey [31]byte
+
 type Assignment struct {
 	WorkReport *block.WorkReport // Work-Report (w)
 	Time       jamtime.Timeslot  // time at which work-report was reported but not yet accumulated (t)


### PR DESCRIPTION
State serialization as per GP 0.6.6 switched from 32 -> 31 byte state keys. This commit adds a StateKey type of [31]byte and updates the state serialisation to use it.

This change doesn't change much practically since the last byte was unused anyway.

Also some small refactors for clarity.