### PR TITLE
Deserialize preimages

### DIFF
--- a/internal/state/merkle/deserialization.go
+++ b/internal/state/merkle/deserialization.go
@@ -1,6 +1,7 @@
 package merkle
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	"github.com/eigerco/strawberry/internal/block"
@@ -10,24 +11,25 @@ import (
 	"github.com/eigerco/strawberry/pkg/serialization/codec/jam"
 )
 
-// DeserializeState deserializes the given map of state keys to byte slices into a State object. Not possible to restore the full state.
+// DeserializeState deserializes the given map of state keys to byte slices into a State object.
 func DeserializeState(serializedState map[state.StateKey][]byte) (state.State, error) {
 	deserializedState := state.State{}
 
-	// Helper function to deserialize individual fields
+	// Helper function to deserialize individual fields for chapter state keys.
 	deserializeField := func(key uint8, target interface{}) error {
 		stateKey := generateStateKeyBasic(key)
 		encodedValue, ok := serializedState[stateKey]
 		if !ok {
-			return fmt.Errorf("missing state key %v", key)
+			return fmt.Errorf("deserialize state: missing state key %v", key)
 		}
 		return jam.Unmarshal(encodedValue, target)
 	}
 
-	// Deserialize basic fields
+	// Deserialize basic fields (chapter state keys)
+	// These can simply be looked up.
 	basicFields := []struct {
 		key   uint8
-		value interface{}
+		value any
 	}{
 		{1, &deserializedState.CoreAuthorizersPool},
 		{2, &deserializedState.PendingAuthorizersQueues},
@@ -52,64 +54,172 @@ func DeserializeState(serializedState map[state.StateKey][]byte) (state.State, e
 		}
 	}
 
+	// Sort keys into service account keys and preimage lookup keys.
+	var serviceKeys, preimageLookupKeys []state.StateKey
+	for stateKey := range serializedState {
+		if IsChapterKey(stateKey) {
+			continue
+		} else if IsServiceAccountKey(stateKey) {
+			serviceKeys = append(serviceKeys, stateKey)
+		} else if IsPreimageLookupKey(stateKey) {
+			preimageLookupKeys = append(preimageLookupKeys, stateKey)
+		}
+
+		// TODO storage and preimage meta keys.
+	}
+
 	// Deserialize Services
-	if err := deserializeServices(&deserializedState, serializedState); err != nil {
-		return deserializedState, err
+	for _, serviceKey := range serviceKeys {
+		if err := deserializeService(&deserializedState, serviceKey, serializedState[serviceKey]); err != nil {
+			return deserializedState, err
+		}
+	}
+
+	// Deserialize Preimage Lookups
+	for _, preimageLookupKey := range preimageLookupKeys {
+		if err := deserializePreimageLookup(&deserializedState, preimageLookupKey, serializedState[preimageLookupKey]); err != nil {
+			return deserializedState, err
+		}
 	}
 
 	return deserializedState, nil
 }
 
-func deserializeServices(state *state.State, serializedState map[state.StateKey][]byte) error {
-	state.Services = make(service.ServiceState)
-
-	// Iterate over serializedState and look for service entries (identified by prefix 255)
-	for stateKey, encodedValue := range serializedState {
-		// Check if this is a service account entry (state key starts with 255)
-		if isServiceAccountKey(stateKey) {
-			// Extract service ID from the key
-			serviceId, err := extractServiceIdFromKey(stateKey)
-			if err != nil {
-				return err
-			}
-
-			// Deserialize the combined fields (CodeHash, Balance, etc.)
-			var combined struct {
-				CodeHash               crypto.Hash
-				Balance                uint64
-				GasLimitForAccumulator uint64
-				GasLimitOnTransfer     uint64
-				FootprintSize          uint64
-				FootprintItems         int
-			}
-			if err := jam.Unmarshal(encodedValue, &combined); err != nil {
-				return err
-			}
-
-			// Create and populate the ServiceAccount from the deserialized data
-			serviceAccount := service.ServiceAccount{
-				CodeHash:               combined.CodeHash,
-				Balance:                combined.Balance,
-				GasLimitForAccumulator: combined.GasLimitForAccumulator,
-				GasLimitOnTransfer:     combined.GasLimitOnTransfer,
-			}
-
-			// We cannot completely deserialize storage and preimage items. That's why they are not here.
-
-			// Add the deserialized service account to the state
-			state.Services[serviceId] = serviceAccount
-		}
+// DeserializeService deserializes a service account from the given state key and encoded value.
+func deserializeService(state *state.State, stateKey state.StateKey, encodedValue []byte) error {
+	if !IsServiceAccountKey(stateKey) {
+		return fmt.Errorf("deserialize service: expected service account key, got %v", hex.EncodeToString(stateKey[:]))
 	}
+
+	if state.Services == nil {
+		state.Services = make(service.ServiceState)
+	}
+
+	_, serviceId, err := extractStateKeyChapterServiceID(stateKey)
+	if err != nil {
+		return err
+	}
+
+	// Deserialize the combined fields (CodeHash, Balance, etc.)
+	var combined struct {
+		CodeHash               crypto.Hash
+		Balance                uint64
+		GasLimitForAccumulator uint64
+		GasLimitOnTransfer     uint64
+		FootprintSize          uint64
+		FootprintItems         uint32
+	}
+	if err := jam.Unmarshal(encodedValue, &combined); err != nil {
+		return fmt.Errorf("deserialize service: error unmarshalling: %w", err)
+	}
+
+	// Create and populate the ServiceAccount from the deserialized data
+	serviceAccount := service.ServiceAccount{
+		CodeHash:               combined.CodeHash,
+		Balance:                combined.Balance,
+		GasLimitForAccumulator: combined.GasLimitForAccumulator,
+		GasLimitOnTransfer:     combined.GasLimitOnTransfer,
+	}
+
+	state.Services[serviceId] = serviceAccount
 
 	return nil
 }
 
-func isServiceAccountKey(stateKey state.StateKey) bool {
-	// Check if the first byte of the state key is 255 (which identifies service keys)
-	return stateKey[0] == 255
+// DeserializePreimageLookup deserializes a preimage lookup from the given state key and encoded value.
+// The original preimage lookup hash is found by simply hashing the decoded value.
+func deserializePreimageLookup(state *state.State, stateKey state.StateKey, encodedValue []byte) error {
+	if !IsPreimageLookupKey(stateKey) {
+		return fmt.Errorf("deserialize preimage lookup: expected preimage lookup key, got '%v'", hex.EncodeToString(stateKey[:]))
+	}
+
+	serviceId, _, err := extractStateKeyServiceIDHash(stateKey)
+	if err != nil {
+		return err
+	}
+
+	if state.Services == nil {
+		return fmt.Errorf("deserializing preimage lookup: services map empty")
+	}
+
+	serviceAccount, ok := state.Services[serviceId]
+	if !ok {
+		return fmt.Errorf("deserializing preimage lookup: service ID '%v' does not exist", serviceId)
+	}
+
+	preimageBlob := []byte{}
+	if err := jam.Unmarshal(encodedValue, &preimageBlob); err != nil {
+		return fmt.Errorf("deserializing preimage lookup: error unmarshalling: %w", err)
+	}
+
+	if serviceAccount.PreimageLookup == nil {
+		serviceAccount.PreimageLookup = map[crypto.Hash][]byte{}
+	}
+
+	key := crypto.HashData(preimageBlob)
+	serviceAccount.PreimageLookup[key] = preimageBlob
+
+	state.Services[serviceId] = serviceAccount
+
+	return nil
 }
 
-func extractServiceIdFromKey(stateKey state.StateKey) (block.ServiceId, error) {
+// Checks if the given state key is a chapter key of the format: [i, 0, 0,...]
+func IsChapterKey(stateKey state.StateKey) bool {
+	// Chapter keys start with 1-15.
+	if !(stateKey[0] > 0 && stateKey[0] < 16) {
+		return false
+	}
+
+	// And then the rest of the bytes must be 0.
+	for _, byte := range stateKey[1:] {
+		if byte != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// Checks if the given state key is a service account key of the format: [255, n0, 0, n1, 0, n2, 0, n3, 0, 0,...]
+// Where n is the server ID uint32 little endian encoded.
+func IsServiceAccountKey(stateKey state.StateKey) bool {
+	if !(stateKey[0] == ChapterServiceIndex && // Service account keys start with 255.
+		stateKey[2] == 0 && stateKey[4] == 0 && stateKey[6] == 0) {
+		return false
+	}
+
+	// And then the rest of the bytes must be 0.
+	for _, byte := range stateKey[8:] {
+		if byte != 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Checks if the given state key is a preimage lookup key of the format: [n0, 0xFE, n1, 0xFF, n2, 0xFF, n3, 0xFF, h4, h5,...]
+// Where n is the server ID uint32 little endian encoded, and h is the hash component.
+func IsPreimageLookupKey(stateKey state.StateKey) bool {
+	// The preimage lookup keys hash component starts with max(uint32) - 1,
+	// little endian encoded, which is 0xFEFFFFFF. This is interleaved with the
+	// service ID.
+	return stateKey[1] == 0xFE &&
+		stateKey[3] == 0xFF &&
+		stateKey[5] == 0xFF &&
+		stateKey[7] == 0xFF
+
+}
+
+// Extracts the chapter and service ID components from a state key of airty 2.
+// State key is the format: [i, n0, 0, n1, 0, n2, 0, n3, 0, 0,...]
+// where i is an uint8, and n is the server ID uint32 little endian encoded.
+func extractStateKeyChapterServiceID(stateKey state.StateKey) (uint8,
+	block.ServiceId, error) {
+	if !(stateKey[2] == 0 && stateKey[4] == 0 && stateKey[6] == 0) {
+		return 0, 0, fmt.Errorf("extracting chapter and service id: not an airty 2 state key")
+	}
+
 	// Collect service ID bytes from positions 1,3,5,7 into a slice
 	encodedServiceId := []byte{
 		stateKey[1],
@@ -120,8 +230,33 @@ func extractServiceIdFromKey(stateKey state.StateKey) (block.ServiceId, error) {
 
 	var serviceId block.ServiceId
 	if err := jam.Unmarshal(encodedServiceId, &serviceId); err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 
-	return serviceId, nil
+	return stateKey[0], serviceId, nil
+}
+
+// Extracts the service ID and hash components from a state key of airty 3.
+// The state key is the format: [n0, h0, n1, h1, n2, h2, n3, h3, h4, h5,...]
+// Where n is the server ID uint32 little endian encoded, and h is the hash component.
+func extractStateKeyServiceIDHash(stateKey state.StateKey) (block.ServiceId, stateConstructorHashComponent, error) {
+	encodedServiceId := []byte{
+		stateKey[0],
+		stateKey[2],
+		stateKey[4],
+		stateKey[6],
+	}
+
+	var serviceId block.ServiceId
+	if err := jam.Unmarshal(encodedServiceId, &serviceId); err != nil {
+		return 0, stateConstructorHashComponent{}, err
+	}
+
+	hash := stateConstructorHashComponent{}
+	hash[0] = stateKey[1]
+	hash[1] = stateKey[3]
+	hash[2] = stateKey[5]
+	copy(hash[3:], stateKey[7:])
+
+	return serviceId, hash, nil
 }

--- a/internal/state/merkle/deserialization.go
+++ b/internal/state/merkle/deserialization.go
@@ -88,7 +88,7 @@ func DeserializeState(serializedState map[state.StateKey][]byte) (state.State, e
 // DeserializeService deserializes a service account from the given state key and encoded value.
 func deserializeService(state *state.State, stateKey state.StateKey, encodedValue []byte) error {
 	if !IsServiceAccountKey(stateKey) {
-		return fmt.Errorf("deserialize service: expected service account key, got %v", hex.EncodeToString(stateKey[:]))
+		return fmt.Errorf("deserialize service: expected service account key, got %x", stateKey[:])
 	}
 
 	if state.Services == nil {

--- a/internal/state/merkle/serialization.go
+++ b/internal/state/merkle/serialization.go
@@ -10,6 +10,12 @@ import (
 	"github.com/eigerco/strawberry/pkg/serialization/codec/jam"
 )
 
+const (
+	ChapterServiceIndex        = 255
+	ChapterStorageIndex        = math.MaxUint32
+	ChapterPreimageLookupIndex = math.MaxUint32 - 1
+)
+
 // SerializeState serializes the given state into a map of state keys to byte arrays, for merklization.
 // Graypaper 0.5.4.
 func SerializeState(s state.State) (map[state.StateKey][]byte, error) {
@@ -82,82 +88,97 @@ func serializeServiceAccount(serviceId block.ServiceId, serviceAccount service.S
 		return err
 	}
 
-	totalFootprintSize := calculateFootprintSize(serviceAccount.Storage, serviceAccount.PreimageMeta) // ao graypaper 0.5.4
-	encodedFootprintSize, err := jam.Marshal(totalFootprintSize)
+	encodedTotalStorageSize, err := jam.Marshal(serviceAccount.TotalStorageSize())
 	if err != nil {
 		return err
 	}
 
-	footprintItems := 2*len(serviceAccount.PreimageMeta) + len(serviceAccount.Storage)
-	encodedFootprintItems, err := jam.Marshal(footprintItems)
+	encodedTotalItems, err := jam.Marshal(serviceAccount.TotalItems())
 	if err != nil {
 		return err
 	}
 
-	combined := combineEncoded(
+	encodedServiceValue := combineEncoded(
 		encodedCodeHash,
 		encodedBalance,
 		encodedGasLimitForAccumulator,
 		encodedGasLimitOnTransfer,
-		encodedFootprintSize,
-		encodedFootprintItems,
+		encodedTotalStorageSize,
+		encodedTotalItems,
 	)
-	stateKey, err := generateStateKeyInterleavedBasic(255, serviceId)
+	stateKey, err := generateStateKeyInterleavedBasic(ChapterServiceIndex, serviceId)
 	if err != nil {
 		return err
 	}
-	serializedState[stateKey] = combined
+	serializedState[stateKey] = encodedServiceValue
 
-	// Serialize storage and preimage items
-	if err := serializeStorageAndPreimage(serviceId, serviceAccount, serializedState); err != nil {
+	if err := serializeStorage(serviceId, serviceAccount.Storage, serializedState); err != nil {
+		return err
+	}
+
+	if err := serializePreimageLookup(serviceId, serviceAccount.PreimageLookup, serializedState); err != nil {
+		return err
+	}
+
+	if err := serializePreimageMeta(serviceId, serviceAccount.PreimageMeta, serializedState); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func serializeStorageAndPreimage(serviceId block.ServiceId, serviceAccount service.ServiceAccount, serializedState map[state.StateKey][]byte) error {
-	encodedMaxUint32, err := jam.Marshal(math.MaxUint32)
+func serializeStorage(serviceId block.ServiceId, storage map[crypto.Hash][]byte, serializedState map[state.StateKey][]byte) error {
+	chapterIndex, err := jam.Marshal(ChapterStorageIndex)
 	if err != nil {
 		return err
 	}
-	for hash, value := range serviceAccount.Storage {
+
+	for hash, value := range storage {
 		encodedValue, err := jam.Marshal(value)
 		if err != nil {
 			return err
 		}
 
-		var combined stateConstructorHashComponent
-		copy(combined[:4], encodedMaxUint32)
-		copy(combined[4:], hash[:28])
-		stateKey, err := generateStateKeyInterleaved(serviceId, combined)
+		var hashComponent stateConstructorHashComponent
+		copy(hashComponent[:4], chapterIndex)
+		copy(hashComponent[4:], hash[:28])
+		stateKey, err := generateStateKeyInterleaved(serviceId, hashComponent)
 		if err != nil {
 			return err
 		}
 		serializedState[stateKey] = encodedValue
 	}
 
-	encodedMaxUint32MinusOne, err := jam.Marshal(math.MaxUint32 - 1)
+	return nil
+}
+
+func serializePreimageLookup(serviceId block.ServiceId, preimages map[crypto.Hash][]byte, serializedState map[state.StateKey][]byte) error {
+	chapterIndex, err := jam.Marshal(ChapterPreimageLookupIndex)
 	if err != nil {
 		return err
 	}
-	for hash, value := range serviceAccount.PreimageLookup {
+
+	for hash, value := range preimages {
 		encodedValue, err := jam.Marshal(value)
 		if err != nil {
 			return err
 		}
 
-		var combined stateConstructorHashComponent
-		copy(combined[:4], encodedMaxUint32MinusOne)
-		copy(combined[4:], hash[1:29])
-		stateKey, err := generateStateKeyInterleaved(serviceId, combined)
+		var hashComponent stateConstructorHashComponent
+		copy(hashComponent[:4], chapterIndex)
+		copy(hashComponent[4:], hash[1:29])
+		stateKey, err := generateStateKeyInterleaved(serviceId, hashComponent)
 		if err != nil {
 			return err
 		}
 		serializedState[stateKey] = encodedValue
 	}
 
-	for key, preImageHistoricalTimeslots := range serviceAccount.PreimageMeta {
+	return nil
+}
+
+func serializePreimageMeta(serviceId block.ServiceId, preimageMeta map[service.PreImageMetaKey]service.PreimageHistoricalTimeslots, serializedState map[state.StateKey][]byte) error {
+	for key, preImageHistoricalTimeslots := range preimageMeta {
 		encodedLength, err := jam.Marshal(key.Length)
 		if err != nil {
 			return err
@@ -168,14 +189,15 @@ func serializeStorageAndPreimage(serviceId block.ServiceId, serviceAccount servi
 		}
 		hashedPreImageHistoricalTimeslots := crypto.HashData(encodedPreImageHistoricalTimeslots)
 
-		var combined stateConstructorHashComponent
-		copy(combined[:4], encodedLength)
-		copy(combined[4:], hashedPreImageHistoricalTimeslots[2:30])
-		stateKey, err := generateStateKeyInterleaved(serviceId, combined)
+		var hashComponent stateConstructorHashComponent
+		copy(hashComponent[:4], encodedLength)
+		copy(hashComponent[4:], hashedPreImageHistoricalTimeslots[2:30])
+		stateKey, err := generateStateKeyInterleaved(serviceId, hashComponent)
 		if err != nil {
 			return err
 		}
 		serializedState[stateKey] = encodedPreImageHistoricalTimeslots
 	}
+
 	return nil
 }

--- a/internal/state/merkle/serialization.go
+++ b/internal/state/merkle/serialization.go
@@ -11,9 +11,12 @@ import (
 )
 
 const (
-	ChapterServiceIndex        = 255
-	ChapterStorageIndex        = math.MaxUint32
-	ChapterPreimageLookupIndex = math.MaxUint32 - 1
+	// Chapter component for service account state keys.
+	ChapterServiceIndex = 255
+	// Hash component for storage state keys begins this this value little endian encoded.
+	HashStorageIndex = math.MaxUint32 - 1
+	// Hash component for preimage lookup state keys begins this this value little endian encoded.
+	HashPreimageLookupIndex = math.MaxUint32 - 2
 )
 
 // SerializeState serializes the given state into a map of state keys to byte arrays, for merklization.
@@ -128,7 +131,7 @@ func serializeServiceAccount(serviceId block.ServiceId, serviceAccount service.S
 }
 
 func serializeStorage(serviceId block.ServiceId, storage map[crypto.Hash][]byte, serializedState map[state.StateKey][]byte) error {
-	chapterIndex, err := jam.Marshal(ChapterStorageIndex)
+	hashIndex, err := jam.Marshal(HashStorageIndex)
 	if err != nil {
 		return err
 	}
@@ -140,8 +143,8 @@ func serializeStorage(serviceId block.ServiceId, storage map[crypto.Hash][]byte,
 		}
 
 		var hashComponent stateConstructorHashComponent
-		copy(hashComponent[:4], chapterIndex)
-		copy(hashComponent[4:], hash[:28])
+		copy(hashComponent[:4], hashIndex)
+		copy(hashComponent[4:], hash[:24])
 		stateKey, err := generateStateKeyInterleaved(serviceId, hashComponent)
 		if err != nil {
 			return err
@@ -153,7 +156,7 @@ func serializeStorage(serviceId block.ServiceId, storage map[crypto.Hash][]byte,
 }
 
 func serializePreimageLookup(serviceId block.ServiceId, preimages map[crypto.Hash][]byte, serializedState map[state.StateKey][]byte) error {
-	chapterIndex, err := jam.Marshal(ChapterPreimageLookupIndex)
+	hashIndex, err := jam.Marshal(HashPreimageLookupIndex)
 	if err != nil {
 		return err
 	}
@@ -165,8 +168,8 @@ func serializePreimageLookup(serviceId block.ServiceId, preimages map[crypto.Has
 		}
 
 		var hashComponent stateConstructorHashComponent
-		copy(hashComponent[:4], chapterIndex)
-		copy(hashComponent[4:], hash[1:29])
+		copy(hashComponent[:4], hashIndex)
+		copy(hashComponent[4:], hash[1:25])
 		stateKey, err := generateStateKeyInterleaved(serviceId, hashComponent)
 		if err != nil {
 			return err
@@ -191,7 +194,7 @@ func serializePreimageMeta(serviceId block.ServiceId, preimageMeta map[service.P
 
 		var hashComponent stateConstructorHashComponent
 		copy(hashComponent[:4], encodedLength)
-		copy(hashComponent[4:], hashedPreImageHistoricalTimeslots[2:30])
+		copy(hashComponent[4:], hashedPreImageHistoricalTimeslots[2:26])
 		stateKey, err := generateStateKeyInterleaved(serviceId, hashComponent)
 		if err != nil {
 			return err

--- a/internal/state/merkle/serialization_utils.go
+++ b/internal/state/merkle/serialization_utils.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/eigerco/strawberry/internal/block"
 	"github.com/eigerco/strawberry/internal/crypto"
-	"github.com/eigerco/strawberry/internal/service"
 	"github.com/eigerco/strawberry/internal/state"
 )
 
@@ -77,23 +76,6 @@ func generateStateKeyInterleaved(s block.ServiceId, h stateConstructorHashCompon
 	copy(result[8:], h[4:])
 
 	return result, nil
-}
-
-// calculateFootprintSize calculates the storage footprint size (al) based on Equation 94.
-func calculateFootprintSize(storage map[crypto.Hash][]byte, preimageMeta map[service.PreImageMetaKey]service.PreimageHistoricalTimeslots) uint64 {
-	var totalSize uint64 = 0
-
-	// Calculate the footprint size for the preimage metadata
-	for key := range preimageMeta {
-		totalSize += uint64(81 + key.Length)
-	}
-
-	// Calculate the footprint size for the storage items
-	for _, value := range storage {
-		totalSize += uint64(32 + len(value))
-	}
-
-	return totalSize
 }
 
 // combineEncoded takes multiple encoded byte arrays and concatenates them into a single byte array.

--- a/internal/state/merkle/serialization_utils_test.go
+++ b/internal/state/merkle/serialization_utils_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/eigerco/strawberry/internal/block"
-	"github.com/eigerco/strawberry/internal/crypto"
-	"github.com/eigerco/strawberry/internal/service"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -69,7 +67,7 @@ func TestGenerateStateKeyInterleavedBasic(t *testing.T) {
 			}
 
 			// Verify we can extract the service ID back
-			extractedServiceId, err := extractServiceIdFromKey(stateKey)
+			_, extractedServiceId, err := extractStateKeyChapterServiceID(stateKey)
 			require.NoError(t, err)
 			assert.Equal(t, tt.serviceId, extractedServiceId)
 		})
@@ -108,23 +106,6 @@ func TestGenerateStateKeyInterleaved(t *testing.T) {
 			assert.Equal(t, byte(0), rest[i], "should be zero at position %d", i)
 		}
 	}
-}
-
-// TestCalculateFootprintSize checks if the footprint size calculation is correct.
-func TestCalculateFootprintSize(t *testing.T) {
-	storage := map[crypto.Hash][]byte{
-		{0x01}: {0x01, 0x02, 0x03},
-	}
-	preimageMeta := map[service.PreImageMetaKey]service.PreimageHistoricalTimeslots{
-		{Hash: crypto.Hash{0x02}, Length: 32}: {},
-	}
-
-	// Calculate footprint size
-	footprintSize := calculateFootprintSize(storage, preimageMeta)
-
-	// Verify the calculation
-	expectedSize := uint64(81+32) + uint64(32+3)
-	assert.Equal(t, expectedSize, footprintSize)
 }
 
 // TestCombineEncoded verifies that combining multiple encoded fields works as expected.

--- a/tests/integration/state_serialization_test.go
+++ b/tests/integration/state_serialization_test.go
@@ -39,15 +39,12 @@ func TestStateSerialization(t *testing.T) {
 		// Check only the keys we're currently able to serialize.
 		// We are missing storage and preimage meta dicts for now.
 		originalValue, ok := serializedState[key]
-		if !ok {
-			continue
-		}
+		require.True(t, ok, "missed key %s", hex.EncodeToString(key[:]))
 
-		// We aren't deserializing storage and preimate meta dicts yet, so the
-		// total storage / total items fields are incorrect for now. Those
-		// values are the last 12 bytes of the encoded value, so we remove that
-		// for now to be able to test the rest of the service fields in the
-		// meantime.
+		// We aren't deserializing storage dicts yet, so the total storage and
+		// total items fields are incorrect for now. Those values are the last
+		// 12 bytes of the encoded value, so we remove that for now to be able
+		// to test the rest of the service fields in the meantime.
 		if merkle.IsServiceAccountKey(key) {
 			originalValue = originalValue[:len(originalValue)-12]
 			value = value[:len(value)-12]

--- a/tests/integration/state_serialization_test.go
+++ b/tests/integration/state_serialization_test.go
@@ -3,6 +3,7 @@
 package integration_test
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"testing"
@@ -34,10 +35,26 @@ func TestStateSerialization(t *testing.T) {
 	newSerializedState, err := merkle.SerializeState(decodedState)
 	require.NoError(t, err)
 
-	// Check only the keys we're currently able to serialize.
-	// We are missing storage, preimage, and preimage lookup dicts for now.
 	for key, value := range newSerializedState {
-		require.Equal(t, value, newSerializedState[key])
+		// Check only the keys we're currently able to serialize.
+		// We are missing storage and preimage meta dicts for now.
+		originalValue, ok := serializedState[key]
+		if !ok {
+			continue
+		}
+
+		// We aren't deserializing storage and preimate meta dicts yet, so the
+		// total storage / total items fields are incorrect for now. Those
+		// values are the last 12 bytes of the encoded value, so we remove that
+		// for now to be able to test the rest of the service fields in the
+		// meantime.
+		if merkle.IsServiceAccountKey(key) {
+			originalValue = originalValue[:len(originalValue)-12]
+			value = value[:len(value)-12]
+		}
+
+		require.Equal(t, hex.EncodeToString(originalValue), hex.EncodeToString(value),
+			"key %s", hex.EncodeToString(key[:]))
 	}
 
 }


### PR DESCRIPTION
- Move deserialization functions to their own file.
- Sort by the type of key before deserializing for efficiency and clarity.
- Add deserialization for preimages. This is fairly straight forward since we can just hash the preimage to get back it's key.
- Fix service serialization, total items/storage should use the functions on the service account for this and not do their own calculation.
- Fix state serialization integration test, there was a bug where we weren't checking the correct state. Also ignore the storage/items fields of the service account for now in the test since we won't get correct values for these until we're also deserializing storage keys.
- Some refactoring for clarity.