### PR TITLE
Fix activity stats epoch change bug

### DIFF
--- a/tests/simulation/simulation_ticket_test.go
+++ b/tests/simulation/simulation_ticket_test.go
@@ -30,6 +30,8 @@ func TestSimulateTicket(t *testing.T) {
 	restoredPreState := jsonutils.RestoreStateSnapshot(data)
 	currentState = &restoredPreState
 
+	preActivityStats := currentState.ActivityStatistics
+
 	// Block
 	data, err = os.ReadFile("ticket_block_001.json")
 	require.NoError(t, err)
@@ -68,4 +70,12 @@ func TestSimulateTicket(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, postStateTicketIDs, ticketID)
 	}
+
+	// Check that validator activity stats were rotated correctly on epoch
+	// change. Current should become last.
+	require.Equal(t, preActivityStats.ValidatorsCurrent, currentState.ActivityStatistics.ValidatorsLast)
+
+	// Our validator should have 1 block and 3 tickets in this new epoch.
+	require.Equal(t, uint32(1), currentState.ActivityStatistics.ValidatorsCurrent[testBlock.Header.BlockAuthorIndex].NumOfBlocks)
+	require.Equal(t, uint32(3), currentState.ActivityStatistics.ValidatorsCurrent[testBlock.Header.BlockAuthorIndex].NumOfTickets)
 }

--- a/tests/simulation/ticket_prestate_001.json
+++ b/tests/simulation/ticket_prestate_001.json
@@ -435,7 +435,15 @@
     "pi": {
         "vals_current": [
             {
-                "blocks": 0,
+                "blocks": 3,
+                "tickets": 3,
+                "pre_images": 0,
+                "pre_images_size": 0,
+                "guarantees": 0,
+                "assurances": 0
+            },
+            {
+                "blocks": 2,
                 "tickets": 0,
                 "pre_images": 0,
                 "pre_images_size": 0,
@@ -459,24 +467,16 @@
                 "assurances": 0
             },
             {
-                "blocks": 0,
-                "tickets": 0,
+                "blocks": 6,
+                "tickets": 11,
                 "pre_images": 0,
                 "pre_images_size": 0,
                 "guarantees": 0,
                 "assurances": 0
             },
             {
-                "blocks": 0,
-                "tickets": 0,
-                "pre_images": 0,
-                "pre_images_size": 0,
-                "guarantees": 0,
-                "assurances": 0
-            },
-            {
-                "blocks": 0,
-                "tickets": 0,
+                "blocks": 1,
+                "tickets": 3,
                 "pre_images": 0,
                 "pre_images_size": 0,
                 "guarantees": 0,


### PR DESCRIPTION
We were passing the next timeslot instead of the previous timeslot to CalculateActivityStatistics in UpdateState. So the stats weren't rotating on epoch change. Passing the correct timeslot fixes this issue.

Also:
- Add a test for this in the simulate ticket test. This test covers an epoch change so it's a good place to test that validator stats actually rotate.