### PR TITLE
Fix PVM program blob parsing

### DIFF
--- a/internal/statetransition/accumulate.go
+++ b/internal/statetransition/accumulate.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 
 	"github.com/eigerco/strawberry/internal/jamtime"
+	"github.com/eigerco/strawberry/internal/state/serialization/statekey"
 
 	"github.com/eigerco/strawberry/internal/block"
 	"github.com/eigerco/strawberry/internal/crypto"
@@ -78,6 +79,16 @@ func (a *Accumulator) InvokePVM(accState state.AccumulationState, newTime jamtim
 	hostCallFunc := func(hostCall uint64, gasCounter polkavm.Gas, regs polkavm.Registers, mem polkavm.Memory, ctx polkavm.AccumulateContextPair) (polkavm.Gas, polkavm.Registers, polkavm.Memory, polkavm.AccumulateContextPair, error) {
 		// s
 		currentService := accState.ServiceState[serviceIndex]
+		if currentService.Storage == nil {
+			currentService.Storage = make(map[statekey.StateKey][]byte)
+		}
+		if currentService.PreimageLookup == nil {
+			currentService.PreimageLookup = make(map[crypto.Hash][]byte)
+		}
+		if currentService.PreimageMeta == nil {
+			currentService.PreimageMeta = make(map[service.PreImageMetaKey]service.PreimageHistoricalTimeslots)
+		}
+
 		var err error
 		switch hostCall {
 		case host_call.GasID:

--- a/tests/integration/accumulate_test.go
+++ b/tests/integration/accumulate_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/eigerco/strawberry/internal/jamtime"
 	"github.com/eigerco/strawberry/internal/service"
 	"github.com/eigerco/strawberry/internal/state"
+	"github.com/eigerco/strawberry/internal/state/serialization/statekey"
 	"github.com/eigerco/strawberry/internal/statetransition"
 	"github.com/stretchr/testify/assert"
 
@@ -136,6 +137,15 @@ func TestAccumulate(t *testing.T) {
 				newState.ValidatorState.QueuedValidators,
 				newState.PendingAuthorizersQueues,
 				_ = statetransition.CalculateWorkReportsAndAccumulate(header, preState, newState.TimeslotIndex, workReports)
+
+			// TODO check storage properly when we update to the v0.6.5 vectors.
+			// For now ignore storage since it's set by the accumulate code and
+			// not yet in the test vectors.
+			for serviceId, service := range newState.Services {
+				service.Storage = make(map[statekey.StateKey][]byte)
+				newState.Services[serviceId] = service
+			}
+
 			assert.Equal(t, postState, newState)
 		})
 	}
@@ -241,6 +251,8 @@ func mapAccumulateServices(t *testing.T, accounts []AccumulateServiceAccount) se
 	for _, account := range accounts {
 		sa := service.ServiceAccount{
 			PreimageLookup:         make(map[crypto.Hash][]byte),
+			PreimageMeta:           make(map[service.PreImageMetaKey]service.PreimageHistoricalTimeslots),
+			Storage:                make(map[statekey.StateKey][]byte),
 			CodeHash:               mapHash(account.Data.Service.CodeHash),
 			Balance:                account.Data.Service.Balance,
 			GasLimitForAccumulator: account.Data.Service.MinItemGas,


### PR DESCRIPTION
The program blob now includes metadata first, and then the rest of the program blob. Parse this first and update our validation checks.

Also fix the accumulate test. The accumulate code is running now so a storage key is set by it. For now we need to ignore storage keys when checking state equality until we update to the v0.6.5 vectors which do contain storage keys as part of the vector's state.