### PR TITLE
Update disputes test vectors

### DIFF
--- a/tests/integration/assurances_test.go
+++ b/tests/integration/assurances_test.go
@@ -159,7 +159,7 @@ func mapReport(r *Report) *block.WorkReport {
 				PayloadHash:            mapHash(rr.PayloadHash),
 				GasPrioritizationRatio: rr.Gas,
 				Output: block.WorkResultOutputOrError{
-					Inner: rr.Result.Ok,
+					Inner: mustStringToHex(rr.Result.Ok),
 				},
 			}
 		}),

--- a/tests/integration/vectors/disputes/tiny/progress_invalidates_avail_assignments-1.json
+++ b/tests/integration/vectors/disputes/tiny/progress_invalidates_avail_assignments-1.json
@@ -3,50 +3,88 @@
         "disputes": {
             "verdicts": [
                 {
-                    "target": "0x0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
-                    "age": 1,
+                    "target": "0x253a07e4ceacf3541a6b529c5d8089180a226d3acb9d10b9c3026cd2744a893b",
+                    "age": 0,
+                    "votes": [
+                        {
+                            "vote": true,
+                            "index": 0,
+                            "signature": "0xd4063f45bd8d8322dd455271d3b6f2dab750bbafeb9d29e9ffb2e39e378c05522ab53e13ffe80cb41febe2a2ed90d1c4c882f504b99edca00fdd164658c41f08"
+                        },
+                        {
+                            "vote": true,
+                            "index": 1,
+                            "signature": "0x0c213ad915eb34c993dbbf63b3730579f1d6db2ddc23c4d400ed3474fdfeb1398691615f320839bc8353941ae51e6f5de0f13dff21bf9129b7467b3f8776c60e"
+                        },
+                        {
+                            "vote": true,
+                            "index": 2,
+                            "signature": "0x2b3909ae9a3ec88a6486a7359695b52ea6a6febe7738f73d1320bc1de7844ee8b62af8b26c2d92f826c816c06b3fa0bccc9d476147836abd9086f31a781a3508"
+                        },
+                        {
+                            "vote": true,
+                            "index": 3,
+                            "signature": "0x2b7711c119b2cc9929e8234fbb210a6d28e6bff9e86ebdf26f07275a02c1f73d76a3fb7268ac3e1117074d6b99560615b90ff60ce34c5bc3b84f96d24314b406"
+                        },
+                        {
+                            "vote": true,
+                            "index": 4,
+                            "signature": "0x843bcd354835f0477e1ff0b995ec3b8311d939031b8fd5210e135fad6ec0c3100f418a99f132c333304bb5c1cf66980d1d296a6265682d980644ce57fc52f70b"
+                        }
+                    ]
+                },
+                {
+                    "target": "0xb02d0c733076bb73458333c09682905985c7a0c62ae1f5dcf2e5b7f045f999e2",
+                    "age": 0,
                     "votes": [
                         {
                             "vote": false,
                             "index": 0,
-                            "signature": "0x2f8476e2c06dec1fd24130363f922f5419d91cd250d0d9448e8db471e08377a8ee927c8ca9c45ff47796cf0dfb35e4aff4fee96cae8dbe40fbd48d1cd59c7f0c"
+                            "signature": "0x3b07fbea06d6fa1059d4c723d96842c8aade6674ba43ea397aa70bea767a1b70723bc25dd07d779945addb49d5556c63d927f89938b98b0621dc5b4f1ee5130f"
                         },
                         {
                             "vote": false,
                             "index": 1,
-                            "signature": "0xdb882bc41e5092908e45feb9c8f86034ac5e8d75c41e40c60dabccadc306aee3f1c521ac1650ea4a0be0368642788e129d6c468eb1f8dfec9d856719a78b3902"
+                            "signature": "0x7a82cec2c6e7c57fb5581dec9ab520f9d3d2c38a651437df9992f8289545463fc7b0c01658c1b977d661d722a61179189f885634abdef262ef9d45cd77852d09"
                         },
                         {
                             "vote": false,
                             "index": 2,
-                            "signature": "0x647c04630e911a432f99e6c1108bcf4c06496754033b77c5eb8271a5d06a85e1884db0fb977e232e416643ccfaf4f334e99f3b8d9cdfc65a8e4ecbc9db284005"
+                            "signature": "0xccc4c431f51ba1f01e3740ad85cdfe0341b357cd39045431745dc4ccfaf0131d68e3223129cbaef0bc7bdb30fd8b10ba92d564a8c59bca7bc400945010f04b07"
                         },
                         {
                             "vote": false,
                             "index": 3,
-                            "signature": "0xdf20eab8438b43d774ac84d4225607cdd4159ee495991c89c9dc302e7d826b53e23b1f266a2dcf915dee277a0bfa0b93c957504503213c3f57a4c08b5ce07f0b"
+                            "signature": "0xaddd98660cf9c5b43e1edd2d6938c4598255d60d9aa1583dbf87bef22e6fdf02b0c5eea985a643cf7e692fe336e25afb99c9055e875bf3a41bdab024e89bca0c"
                         },
                         {
                             "vote": false,
                             "index": 4,
-                            "signature": "0xb95288deca20fcb649a3515ece2f1d147f8c0f3acef20967cd05a7b770c96e2e0928a056af1aa233c45b0a154e31dae842a50ff48f249cc364af20f282db950a"
+                            "signature": "0x8152ae58a98ccecc7c3002b3cc0cc8a3787312819ac1a5ae93a7bb51af42fc62697c8752f5fcf724abdd4bc6010701daf5c4df0067d3421bbc060d89c57ff50a"
                         }
                     ]
                 }
             ],
             "culprits": [
                 {
-                    "target": "0x0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
+                    "target": "0xb02d0c733076bb73458333c09682905985c7a0c62ae1f5dcf2e5b7f045f999e2",
                     "key": "0x22351e22105a19aabb42589162ad7f1ea0df1c25cebf0e4a9fcd261301274862",
-                    "signature": "0xc935d19a67d96edd5bff539e11a0340153acb119d4bb83e7f60aba87e6fec4acb236d19a97476924d311390accede172a045978dcb0a65adb528ff0e7f7cf609"
+                    "signature": "0xbbd48dc11c9b343df501d8473f2736d2bbb09b2b07e9b115179c2d37cde68ffd780dd92e9619aeb423e0901ec5d5a93a6669aa78e526358aaea2ed38978cdd01"
                 },
                 {
-                    "target": "0x0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
+                    "target": "0xb02d0c733076bb73458333c09682905985c7a0c62ae1f5dcf2e5b7f045f999e2",
                     "key": "0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29",
-                    "signature": "0x7ec23531ebc5aa88883a8b8f1f7b1f05ea18fa12f735de02a167309fe41bb0a87f5ff05d7c00c15fbc19f181badd53e0ec25d9a62e742d239c2058f4964b040f"
+                    "signature": "0x49b6f5c63ab2c836263b869fd23b96b7440a64fd2790e7c63e6f21add5e5fcfff064e4ce47545d645fc5469f29162453c1d06179909b9335e26d8250ffed7602"
                 }
             ],
-            "faults": []
+            "faults": [
+                {
+                    "target": "0x253a07e4ceacf3541a6b529c5d8089180a226d3acb9d10b9c3026cd2744a893b",
+                    "vote": false,
+                    "key": "0xb3e0e096b02e2ec98a3441410aeddd78c95e27a0da6f411a09c631c0f2bea6e9",
+                    "signature": "0x9d4b33e9d9a756b3364534f39f38a81b157d79ab5969c834b88c5b0d8f476bec759c5b2a67fea4b66356983b2740b5638b8b41b7d2431f27989a4777f3aaa30d"
+                }
+            ]
         }
     },
     "pre_state": {
@@ -57,10 +95,94 @@
             "offenders": []
         },
         "rho": [
-            null,
-            null
+            {
+                "report": {
+                    "package_spec": {
+                        "hash": "0x11da6d1f761ddf9bdb4c9d6e5303ebd41f61858d0a5647a1a7bfe089bf921be9",
+                        "length": 0,
+                        "erasure_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "exports_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "exports_count": 0
+                    },
+                    "context": {
+                        "anchor": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "state_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "beefy_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "lookup_anchor": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "lookup_anchor_slot": 0,
+                        "prerequisites": []
+                    },
+                    "core_index": 0,
+                    "authorizer_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "auth_output": "0x030201",
+                    "segment_root_lookup": [],
+                    "results": [
+                        {
+                            "service_id": 0,
+                            "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                            "payload_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                            "accumulate_gas": 42,
+                            "result": {
+                                "ok": "0x010203"
+                            },
+                            "refine_load": {
+                                "gas_used": 0,
+                                "imports": 0,
+                                "extrinsic_count": 0,
+                                "extrinsic_size": 0,
+                                "exports": 0
+                            }
+                        }
+                    ],
+                    "auth_gas_used": 0
+                },
+                "timeout": 42
+            },
+            {
+                "report": {
+                    "package_spec": {
+                        "hash": "0xe12c22d4f162d9a012c9319233da5d3e923cc5e1029b8f90e47249c9ab256b35",
+                        "length": 0,
+                        "erasure_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "exports_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "exports_count": 0
+                    },
+                    "context": {
+                        "anchor": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "state_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "beefy_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "lookup_anchor": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "lookup_anchor_slot": 0,
+                        "prerequisites": []
+                    },
+                    "core_index": 1,
+                    "authorizer_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "auth_output": "0x030201",
+                    "segment_root_lookup": [],
+                    "results": [
+                        {
+                            "service_id": 1,
+                            "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                            "payload_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                            "accumulate_gas": 42,
+                            "result": {
+                                "ok": "0x010203"
+                            },
+                            "refine_load": {
+                                "gas_used": 0,
+                                "imports": 0,
+                                "extrinsic_count": 0,
+                                "extrinsic_size": 0,
+                                "exports": 0
+                            }
+                        }
+                    ],
+                    "auth_gas_used": 0
+                },
+                "timeout": 42
+            }
         ],
-        "tau": 36,
+        "tau": 0,
         "kappa": [
             {
                 "bandersnatch": "0x5e465beb01dbafe160ce8216047f2155dd0569f058afd52dcea601025a8d161d",
@@ -139,20 +261,76 @@
         ]
     },
     "output": {
-        "err": "bad_judgement_age"
+        "ok": {
+            "offenders_mark": [
+                "0x22351e22105a19aabb42589162ad7f1ea0df1c25cebf0e4a9fcd261301274862",
+                "0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29",
+                "0xb3e0e096b02e2ec98a3441410aeddd78c95e27a0da6f411a09c631c0f2bea6e9"
+            ]
+        }
     },
     "post_state": {
         "psi": {
-            "good": [],
-            "bad": [],
+            "good": [
+                "0x253a07e4ceacf3541a6b529c5d8089180a226d3acb9d10b9c3026cd2744a893b"
+            ],
+            "bad": [
+                "0xb02d0c733076bb73458333c09682905985c7a0c62ae1f5dcf2e5b7f045f999e2"
+            ],
             "wonky": [],
-            "offenders": []
+            "offenders": [
+                "0x22351e22105a19aabb42589162ad7f1ea0df1c25cebf0e4a9fcd261301274862",
+                "0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29",
+                "0xb3e0e096b02e2ec98a3441410aeddd78c95e27a0da6f411a09c631c0f2bea6e9"
+            ]
         },
         "rho": [
             null,
-            null
+            {
+                "report": {
+                    "package_spec": {
+                        "hash": "0xe12c22d4f162d9a012c9319233da5d3e923cc5e1029b8f90e47249c9ab256b35",
+                        "length": 0,
+                        "erasure_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "exports_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "exports_count": 0
+                    },
+                    "context": {
+                        "anchor": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "state_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "beefy_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "lookup_anchor": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "lookup_anchor_slot": 0,
+                        "prerequisites": []
+                    },
+                    "core_index": 1,
+                    "authorizer_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "auth_output": "0x030201",
+                    "segment_root_lookup": [],
+                    "results": [
+                        {
+                            "service_id": 1,
+                            "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                            "payload_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                            "accumulate_gas": 42,
+                            "result": {
+                                "ok": "0x010203"
+                            },
+                            "refine_load": {
+                                "gas_used": 0,
+                                "imports": 0,
+                                "extrinsic_count": 0,
+                                "extrinsic_size": 0,
+                                "exports": 0
+                            }
+                        }
+                    ],
+                    "auth_gas_used": 0
+                },
+                "timeout": 42
+            }
         ],
-        "tau": 36,
+        "tau": 0,
         "kappa": [
             {
                 "bandersnatch": "0x5e465beb01dbafe160ce8216047f2155dd0569f058afd52dcea601025a8d161d",

--- a/tests/integration/vectors/disputes/tiny/progress_with_bad_signatures-1.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_bad_signatures-1.json
@@ -24,7 +24,7 @@
                         {
                             "vote": false,
                             "index": 3,
-                            "signature": "0xdf20eab8438b43d774ac84d4225607cdd4159ee495991c89c9dc302e7d826b53e23b1f266a2dcf915dee277a0bfa0b93c957504503213c3f57a4c08b5ce07f0b"
+                            "signature": "0x32d812ab1689708f9b15102ebaee03c27e12d906d74e4f828407cb5084c7b462b7dbf50ce763ce1a74e448b4a44aafe4d73074f1e7bc46d3c9b65bf5d78ca20d"
                         },
                         {
                             "vote": false,
@@ -51,10 +51,10 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,
@@ -143,10 +143,10 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,

--- a/tests/integration/vectors/disputes/tiny/progress_with_bad_signatures-2.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_bad_signatures-2.json
@@ -37,13 +37,13 @@
             "culprits": [
                 {
                     "target": "0x0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
-                    "key": "0xb3e0e096b02e2ec98a3441410aeddd78c95e27a0da6f411a09c631c0f2bea6e9",
-                    "signature": "0xc935d19a67d96edd5bff539e11a0340153acb119d4bb83e7f60aba87e6fec4acb236d19a97476924d311390accede172a045978dcb0a65adb528ff0e7f7cf609"
+                    "key": "0x5c7f34a4bd4f2d04076a8c6f9060a0c8d2c6bdd082ceb3eda7df381cb260faff",
+                    "signature": "0xd5cb84d8e0ea77941eb2a1e5cba3eb916c1ead28bdd0a05a43ab640ea07fd00e3c055a0a90b3a66953fe6f8efc5dca3b3d4acf849870b1904ff770d00ec6860c"
                 },
                 {
                     "target": "0x0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
-                    "key": "0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29",
-                    "signature": "0x7ec23531ebc5aa88883a8b8f1f7b1f05ea18fa12f735de02a167309fe41bb0a87f5ff05d7c00c15fbc19f181badd53e0ec25d9a62e742d239c2058f4964b040f"
+                    "key": "0xb3e0e096b02e2ec98a3441410aeddd78c95e27a0da6f411a09c631c0f2bea6e9",
+                    "signature": "0x6cfa774b471ac2df262d2762e77b2c74b6f912c7482b61435c0af6ca7a77b05f4c102b1c96950aa5f073a35908970da8387285b7083d9ea9220a04b93be9f303"
                 }
             ],
             "faults": []
@@ -51,15 +51,10 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [
-                "0x0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8"
-            ],
-            "psi_w": [],
-            "psi_o": [
-                "0x22351e22105a19aabb42589162ad7f1ea0df1c25cebf0e4a9fcd261301274862",
-                "0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
-            ]
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,
@@ -148,15 +143,10 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [
-                "0x0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8"
-            ],
-            "psi_w": [],
-            "psi_o": [
-                "0x22351e22105a19aabb42589162ad7f1ea0df1c25cebf0e4a9fcd261301274862",
-                "0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
-            ]
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,

--- a/tests/integration/vectors/disputes/tiny/progress_with_culprits-1.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_culprits-1.json
@@ -40,10 +40,10 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,
@@ -132,10 +132,10 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,

--- a/tests/integration/vectors/disputes/tiny/progress_with_culprits-2.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_culprits-2.json
@@ -46,10 +46,10 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,
@@ -138,10 +138,10 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,

--- a/tests/integration/vectors/disputes/tiny/progress_with_culprits-3.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_culprits-3.json
@@ -51,10 +51,10 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,
@@ -143,10 +143,10 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,

--- a/tests/integration/vectors/disputes/tiny/progress_with_culprits-4.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_culprits-4.json
@@ -51,10 +51,10 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,
@@ -148,12 +148,12 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [
+            "good": [],
+            "bad": [
                 "0x11da6d1f761ddf9bdb4c9d6e5303ebd41f61858d0a5647a1a7bfe089bf921be9"
             ],
-            "psi_w": [],
-            "psi_o": [
+            "wonky": [],
+            "offenders": [
                 "0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29",
                 "0xe68e0cf7f26c59f963b5846202d2327cc8bc0c4eff8cb9abd4012f9a71decf00"
             ]

--- a/tests/integration/vectors/disputes/tiny/progress_with_culprits-5.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_culprits-5.json
@@ -51,12 +51,12 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [
+            "good": [],
+            "bad": [
                 "0x11da6d1f761ddf9bdb4c9d6e5303ebd41f61858d0a5647a1a7bfe089bf921be9"
             ],
-            "psi_w": [],
-            "psi_o": []
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,
@@ -145,12 +145,12 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [
+            "good": [],
+            "bad": [
                 "0x11da6d1f761ddf9bdb4c9d6e5303ebd41f61858d0a5647a1a7bfe089bf921be9"
             ],
-            "psi_w": [],
-            "psi_o": []
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,

--- a/tests/integration/vectors/disputes/tiny/progress_with_culprits-6.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_culprits-6.json
@@ -51,10 +51,10 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": [
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": [
                 "0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
             ]
         },
@@ -145,10 +145,10 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": [
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": [
                 "0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
             ]
         },

--- a/tests/integration/vectors/disputes/tiny/progress_with_culprits-7.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_culprits-7.json
@@ -56,10 +56,10 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,
@@ -148,10 +148,10 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,

--- a/tests/integration/vectors/disputes/tiny/progress_with_faults-1.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_faults-1.json
@@ -40,10 +40,10 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,
@@ -132,10 +132,10 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,

--- a/tests/integration/vectors/disputes/tiny/progress_with_faults-2.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_faults-2.json
@@ -47,10 +47,10 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,
@@ -143,12 +143,12 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [
+            "good": [
                 "0x11da6d1f761ddf9bdb4c9d6e5303ebd41f61858d0a5647a1a7bfe089bf921be9"
             ],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": [
+            "bad": [],
+            "wonky": [],
+            "offenders": [
                 "0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
             ]
         },

--- a/tests/integration/vectors/disputes/tiny/progress_with_faults-3.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_faults-3.json
@@ -53,10 +53,10 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,
@@ -145,10 +145,10 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,

--- a/tests/integration/vectors/disputes/tiny/progress_with_faults-4.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_faults-4.json
@@ -53,10 +53,10 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,
@@ -150,12 +150,12 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [
+            "good": [
                 "0x11da6d1f761ddf9bdb4c9d6e5303ebd41f61858d0a5647a1a7bfe089bf921be9"
             ],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": [
+            "bad": [],
+            "wonky": [],
+            "offenders": [
                 "0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29",
                 "0xe68e0cf7f26c59f963b5846202d2327cc8bc0c4eff8cb9abd4012f9a71decf00"
             ]

--- a/tests/integration/vectors/disputes/tiny/progress_with_faults-5.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_faults-5.json
@@ -47,12 +47,12 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [
+            "good": [],
+            "bad": [],
+            "wonky": [
                 "0x11da6d1f761ddf9bdb4c9d6e5303ebd41f61858d0a5647a1a7bfe089bf921be9"
             ],
-            "psi_o": []
+            "offenders": []
         },
         "rho": [
             null,
@@ -141,12 +141,12 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [
+            "good": [],
+            "bad": [],
+            "wonky": [
                 "0x11da6d1f761ddf9bdb4c9d6e5303ebd41f61858d0a5647a1a7bfe089bf921be9"
             ],
-            "psi_o": []
+            "offenders": []
         },
         "rho": [
             null,

--- a/tests/integration/vectors/disputes/tiny/progress_with_faults-6.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_faults-6.json
@@ -47,10 +47,10 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": [
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": [
                 "0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
             ]
         },
@@ -141,10 +141,10 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": [
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": [
                 "0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
             ]
         },

--- a/tests/integration/vectors/disputes/tiny/progress_with_faults-7.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_faults-7.json
@@ -53,10 +53,10 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,
@@ -145,10 +145,10 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,

--- a/tests/integration/vectors/disputes/tiny/progress_with_invalid_keys-1.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_invalid_keys-1.json
@@ -4,32 +4,32 @@
             "verdicts": [
                 {
                     "target": "0x0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
-                    "age": 1,
+                    "age": 0,
                     "votes": [
                         {
                             "vote": false,
                             "index": 0,
-                            "signature": "0x2f8476e2c06dec1fd24130363f922f5419d91cd250d0d9448e8db471e08377a8ee927c8ca9c45ff47796cf0dfb35e4aff4fee96cae8dbe40fbd48d1cd59c7f0c"
-                        },
-                        {
-                            "vote": false,
-                            "index": 1,
-                            "signature": "0xdb882bc41e5092908e45feb9c8f86034ac5e8d75c41e40c60dabccadc306aee3f1c521ac1650ea4a0be0368642788e129d6c468eb1f8dfec9d856719a78b3902"
-                        },
-                        {
-                            "vote": false,
-                            "index": 2,
                             "signature": "0x647c04630e911a432f99e6c1108bcf4c06496754033b77c5eb8271a5d06a85e1884db0fb977e232e416643ccfaf4f334e99f3b8d9cdfc65a8e4ecbc9db284005"
                         },
                         {
                             "vote": false,
+                            "index": 1,
+                            "signature": "0xb95288deca20fcb649a3515ece2f1d147f8c0f3acef20967cd05a7b770c96e2e0928a056af1aa233c45b0a154e31dae842a50ff48f249cc364af20f282db950a"
+                        },
+                        {
+                            "vote": false,
+                            "index": 2,
+                            "signature": "0x2f8476e2c06dec1fd24130363f922f5419d91cd250d0d9448e8db471e08377a8ee927c8ca9c45ff47796cf0dfb35e4aff4fee96cae8dbe40fbd48d1cd59c7f0c"
+                        },
+                        {
+                            "vote": false,
                             "index": 3,
-                            "signature": "0xdf20eab8438b43d774ac84d4225607cdd4159ee495991c89c9dc302e7d826b53e23b1f266a2dcf915dee277a0bfa0b93c957504503213c3f57a4c08b5ce07f0b"
+                            "signature": "0x8aa6778092622ad32db2aa10d060a2ad9f7b819af62ff5ada7f88616f81a8ffd0889c64cd857785c1d1a28e39fe2164b71555ecad03ad286f2952144a862c205"
                         },
                         {
                             "vote": false,
                             "index": 4,
-                            "signature": "0xb95288deca20fcb649a3515ece2f1d147f8c0f3acef20967cd05a7b770c96e2e0928a056af1aa233c45b0a154e31dae842a50ff48f249cc364af20f282db950a"
+                            "signature": "0xdf20eab8438b43d774ac84d4225607cdd4159ee495991c89c9dc302e7d826b53e23b1f266a2dcf915dee277a0bfa0b93c957504503213c3f57a4c08b5ce07f0b"
                         }
                     ]
                 }
@@ -37,8 +37,8 @@
             "culprits": [
                 {
                     "target": "0x0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
-                    "key": "0x22351e22105a19aabb42589162ad7f1ea0df1c25cebf0e4a9fcd261301274862",
-                    "signature": "0xc935d19a67d96edd5bff539e11a0340153acb119d4bb83e7f60aba87e6fec4acb236d19a97476924d311390accede172a045978dcb0a65adb528ff0e7f7cf609"
+                    "key": "0x1501384b242e92f978cbd478f02d2c7d54e9e1dc2e0c26844b00f4a3547fb0e9",
+                    "signature": "0xe6d6cd650046841d58fda85b809e7b17920dc4602ba8491eba2b0b8eec3af2c9774a4694d356b0dfe6d9d2935caad2f6ceddbd0c1234df2acde977130805ce09"
                 },
                 {
                     "target": "0x0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
@@ -60,7 +60,7 @@
             null,
             null
         ],
-        "tau": 36,
+        "tau": 0,
         "kappa": [
             {
                 "bandersnatch": "0x5e465beb01dbafe160ce8216047f2155dd0569f058afd52dcea601025a8d161d",
@@ -139,7 +139,7 @@
         ]
     },
     "output": {
-        "err": "bad_judgement_age"
+        "err": "bad_guarantor_key"
     },
     "post_state": {
         "psi": {
@@ -152,7 +152,7 @@
             null,
             null
         ],
-        "tau": 36,
+        "tau": 0,
         "kappa": [
             {
                 "bandersnatch": "0x5e465beb01dbafe160ce8216047f2155dd0569f058afd52dcea601025a8d161d",

--- a/tests/integration/vectors/disputes/tiny/progress_with_invalid_keys-2.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_invalid_keys-2.json
@@ -4,49 +4,51 @@
             "verdicts": [
                 {
                     "target": "0x0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
-                    "age": 1,
+                    "age": 0,
                     "votes": [
                         {
-                            "vote": false,
+                            "vote": true,
                             "index": 0,
-                            "signature": "0x2f8476e2c06dec1fd24130363f922f5419d91cd250d0d9448e8db471e08377a8ee927c8ca9c45ff47796cf0dfb35e4aff4fee96cae8dbe40fbd48d1cd59c7f0c"
+                            "signature": "0x5318c6eb6fa8bc2b0be2a5aa5b010589bb2de4a94795af0353fd499647a058395c2b92332ae8bc71561733729f630606886a75ba7cc07ae4ba0f532a7394a20a"
                         },
                         {
-                            "vote": false,
+                            "vote": true,
                             "index": 1,
-                            "signature": "0xdb882bc41e5092908e45feb9c8f86034ac5e8d75c41e40c60dabccadc306aee3f1c521ac1650ea4a0be0368642788e129d6c468eb1f8dfec9d856719a78b3902"
+                            "signature": "0xce6e1806b0e6b3d1d026e0ead1f2f036eb2aa5c9b9b77e6a2b25a48bb7cd19337b0e1056fbda421123e0028a1caa128fc63ab18007e5147836a8822a66fc8202"
                         },
                         {
-                            "vote": false,
+                            "vote": true,
                             "index": 2,
-                            "signature": "0x647c04630e911a432f99e6c1108bcf4c06496754033b77c5eb8271a5d06a85e1884db0fb977e232e416643ccfaf4f334e99f3b8d9cdfc65a8e4ecbc9db284005"
+                            "signature": "0x66d9a8d13f344452ce0f27d64d0c2fbc4b9e0c37b587195cee134e69a25d283f87773e0efca616a4483468040713bfaa46d33118a9fd35c09c0ef3bdfbafbb08"
                         },
                         {
-                            "vote": false,
+                            "vote": true,
                             "index": 3,
-                            "signature": "0xdf20eab8438b43d774ac84d4225607cdd4159ee495991c89c9dc302e7d826b53e23b1f266a2dcf915dee277a0bfa0b93c957504503213c3f57a4c08b5ce07f0b"
+                            "signature": "0x32d812ab1689708f9b15102ebaee03c27e12d906d74e4f828407cb5084c7b462b7dbf50ce763ce1a74e448b4a44aafe4d73074f1e7bc46d3c9b65bf5d78ca20d"
                         },
                         {
-                            "vote": false,
+                            "vote": true,
                             "index": 4,
-                            "signature": "0xb95288deca20fcb649a3515ece2f1d147f8c0f3acef20967cd05a7b770c96e2e0928a056af1aa233c45b0a154e31dae842a50ff48f249cc364af20f282db950a"
+                            "signature": "0xe93e119a35719cf688b8caa86ab54d1a4c5049d15e2d11ca8af695d70eb358069d8e54411d2fbc190eab5405221752bae4e3da9aecfd2b0030e4fb0f1ae40706"
                         }
                     ]
                 }
             ],
-            "culprits": [
+            "culprits": [],
+            "faults": [
                 {
                     "target": "0x0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
-                    "key": "0x22351e22105a19aabb42589162ad7f1ea0df1c25cebf0e4a9fcd261301274862",
-                    "signature": "0xc935d19a67d96edd5bff539e11a0340153acb119d4bb83e7f60aba87e6fec4acb236d19a97476924d311390accede172a045978dcb0a65adb528ff0e7f7cf609"
+                    "vote": false,
+                    "key": "0x1501384b242e92f978cbd478f02d2c7d54e9e1dc2e0c26844b00f4a3547fb0e9",
+                    "signature": "0x44dc517d51b4cd74e31628e8abac2a2a2e043437b208149c02325f877ced90fef5f23b3337920d79626b1400ca102b143e722d529f0d3e56b9d8981b43fe430d"
                 },
                 {
                     "target": "0x0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
-                    "key": "0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29",
-                    "signature": "0x7ec23531ebc5aa88883a8b8f1f7b1f05ea18fa12f735de02a167309fe41bb0a87f5ff05d7c00c15fbc19f181badd53e0ec25d9a62e742d239c2058f4964b040f"
+                    "vote": false,
+                    "key": "0x837ce344bc9defceb0d7de7e9e9925096768b7adb4dad932e532eb6551e0ea02",
+                    "signature": "0xdb882bc41e5092908e45feb9c8f86034ac5e8d75c41e40c60dabccadc306aee3f1c521ac1650ea4a0be0368642788e129d6c468eb1f8dfec9d856719a78b3902"
                 }
-            ],
-            "faults": []
+            ]
         }
     },
     "pre_state": {
@@ -60,7 +62,7 @@
             null,
             null
         ],
-        "tau": 36,
+        "tau": 0,
         "kappa": [
             {
                 "bandersnatch": "0x5e465beb01dbafe160ce8216047f2155dd0569f058afd52dcea601025a8d161d",
@@ -139,7 +141,7 @@
         ]
     },
     "output": {
-        "err": "bad_judgement_age"
+        "err": "bad_auditor_key"
     },
     "post_state": {
         "psi": {
@@ -152,7 +154,7 @@
             null,
             null
         ],
-        "tau": 36,
+        "tau": 0,
         "kappa": [
             {
                 "bandersnatch": "0x5e465beb01dbafe160ce8216047f2155dd0569f058afd52dcea601025a8d161d",

--- a/tests/integration/vectors/disputes/tiny/progress_with_no_verdicts-1.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_no_verdicts-1.json
@@ -8,10 +8,10 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,
@@ -102,10 +102,10 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,

--- a/tests/integration/vectors/disputes/tiny/progress_with_verdict_signatures_from_previous_set-1.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_verdict_signatures_from_previous_set-1.json
@@ -51,10 +51,10 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,
@@ -148,12 +148,12 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [
+            "good": [],
+            "bad": [
                 "0x0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8"
             ],
-            "psi_w": [],
-            "psi_o": [
+            "wonky": [],
+            "offenders": [
                 "0x22351e22105a19aabb42589162ad7f1ea0df1c25cebf0e4a9fcd261301274862",
                 "0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
             ]

--- a/tests/integration/vectors/disputes/tiny/progress_with_verdicts-1.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_verdicts-1.json
@@ -47,10 +47,10 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,
@@ -139,10 +139,10 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,

--- a/tests/integration/vectors/disputes/tiny/progress_with_verdicts-2.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_verdicts-2.json
@@ -47,10 +47,10 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,
@@ -139,10 +139,10 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,

--- a/tests/integration/vectors/disputes/tiny/progress_with_verdicts-3.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_verdicts-3.json
@@ -89,10 +89,10 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,
@@ -181,10 +181,10 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,

--- a/tests/integration/vectors/disputes/tiny/progress_with_verdicts-4.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_verdicts-4.json
@@ -89,10 +89,10 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [],
-            "psi_b": [],
-            "psi_w": [],
-            "psi_o": []
+            "good": [],
+            "bad": [],
+            "wonky": [],
+            "offenders": []
         },
         "rho": [
             null,
@@ -187,14 +187,14 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [
+            "good": [
                 "0x11da6d1f761ddf9bdb4c9d6e5303ebd41f61858d0a5647a1a7bfe089bf921be9"
             ],
-            "psi_b": [
+            "bad": [
                 "0x7b0aa1735e5ba58d3236316c671fe4f00ed366ee72417c9ed02a53a8019e85b8"
             ],
-            "psi_w": [],
-            "psi_o": [
+            "wonky": [],
+            "offenders": [
                 "0x22351e22105a19aabb42589162ad7f1ea0df1c25cebf0e4a9fcd261301274862",
                 "0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29",
                 "0xe68e0cf7f26c59f963b5846202d2327cc8bc0c4eff8cb9abd4012f9a71decf00"

--- a/tests/integration/vectors/disputes/tiny/progress_with_verdicts-5.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_verdicts-5.json
@@ -51,14 +51,14 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [
+            "good": [
                 "0x11da6d1f761ddf9bdb4c9d6e5303ebd41f61858d0a5647a1a7bfe089bf921be9"
             ],
-            "psi_b": [
+            "bad": [
                 "0x7b0aa1735e5ba58d3236316c671fe4f00ed366ee72417c9ed02a53a8019e85b8"
             ],
-            "psi_w": [],
-            "psi_o": [
+            "wonky": [],
+            "offenders": [
                 "0x22351e22105a19aabb42589162ad7f1ea0df1c25cebf0e4a9fcd261301274862",
                 "0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29",
                 "0xe68e0cf7f26c59f963b5846202d2327cc8bc0c4eff8cb9abd4012f9a71decf00"
@@ -151,14 +151,14 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [
+            "good": [
                 "0x11da6d1f761ddf9bdb4c9d6e5303ebd41f61858d0a5647a1a7bfe089bf921be9"
             ],
-            "psi_b": [
+            "bad": [
                 "0x7b0aa1735e5ba58d3236316c671fe4f00ed366ee72417c9ed02a53a8019e85b8"
             ],
-            "psi_w": [],
-            "psi_o": [
+            "wonky": [],
+            "offenders": [
                 "0x22351e22105a19aabb42589162ad7f1ea0df1c25cebf0e4a9fcd261301274862",
                 "0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29",
                 "0xe68e0cf7f26c59f963b5846202d2327cc8bc0c4eff8cb9abd4012f9a71decf00"

--- a/tests/integration/vectors/disputes/tiny/progress_with_verdicts-6.json
+++ b/tests/integration/vectors/disputes/tiny/progress_with_verdicts-6.json
@@ -40,14 +40,14 @@
     },
     "pre_state": {
         "psi": {
-            "psi_g": [
+            "good": [
                 "0x11da6d1f761ddf9bdb4c9d6e5303ebd41f61858d0a5647a1a7bfe089bf921be9"
             ],
-            "psi_b": [
+            "bad": [
                 "0x7b0aa1735e5ba58d3236316c671fe4f00ed366ee72417c9ed02a53a8019e85b8"
             ],
-            "psi_w": [],
-            "psi_o": [
+            "wonky": [],
+            "offenders": [
                 "0x22351e22105a19aabb42589162ad7f1ea0df1c25cebf0e4a9fcd261301274862",
                 "0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29",
                 "0xe68e0cf7f26c59f963b5846202d2327cc8bc0c4eff8cb9abd4012f9a71decf00"
@@ -142,16 +142,16 @@
     },
     "post_state": {
         "psi": {
-            "psi_g": [
+            "good": [
                 "0x11da6d1f761ddf9bdb4c9d6e5303ebd41f61858d0a5647a1a7bfe089bf921be9"
             ],
-            "psi_b": [
+            "bad": [
                 "0x7b0aa1735e5ba58d3236316c671fe4f00ed366ee72417c9ed02a53a8019e85b8"
             ],
-            "psi_w": [
+            "wonky": [
                 "0xe12c22d4f162d9a012c9319233da5d3e923cc5e1029b8f90e47249c9ab256b35"
             ],
-            "psi_o": [
+            "offenders": [
                 "0x22351e22105a19aabb42589162ad7f1ea0df1c25cebf0e4a9fcd261301274862",
                 "0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29",
                 "0xe68e0cf7f26c59f963b5846202d2327cc8bc0c4eff8cb9abd4012f9a71decf00"


### PR DESCRIPTION
Update disputes test vectors. 
Added check for fault or culprit if a validator. 
Added a log in case we failed to hash a work report (was silenced before).