### PR TITLE
Add service stats for accumulation / on transfer

### DIFF
--- a/internal/statetransition/state_transition.go
+++ b/internal/statetransition/state_transition.go
@@ -75,8 +75,6 @@ func UpdateState(s *state.State, newBlock block.Block, chain *store.Chain) error
 	if err != nil {
 		return err
 	}
-	// TODO: pass correct available reports.
-	newValidatorStatistics := CalculateNewActivityStatistics(newBlock, prevTimeSlot, s.ActivityStatistics, reporters, s.ValidatorState.CurrentValidators, []block.WorkReport{})
 
 	workReports := GetAvailableWorkReports(newCoreAssignments)
 
@@ -86,7 +84,7 @@ func UpdateState(s *state.State, newBlock block.Block, chain *store.Chain) error
 		newPrivilegedServices,
 		newQueuedValidators,
 		newPendingCoreAuthorizations,
-		serviceHashPairs, _, _ := CalculateWorkReportsAndAccumulate(
+		serviceHashPairs, accumulationStats, transferStats := CalculateWorkReportsAndAccumulate(
 		&newBlock.Header,
 		s,
 		newTimeSlot,
@@ -96,6 +94,10 @@ func UpdateState(s *state.State, newBlock block.Block, chain *store.Chain) error
 	if err != nil {
 		return err
 	}
+
+	// TODO: pass correct available reports.
+	newValidatorStatistics := CalculateNewActivityStatistics(newBlock, prevTimeSlot, s.ActivityStatistics, reporters, s.ValidatorState.CurrentValidators,
+		[]block.WorkReport{}, accumulationStats, transferStats)
 
 	intermediateRecentBlocks := calculateIntermediateBlockState(newBlock.Header, s.RecentBlocks)
 	newRecentBlocks, err := calculateNewRecentBlocks(newBlock.Header, newBlock.Extrinsic.EG, intermediateRecentBlocks, serviceHashPairs)
@@ -2191,6 +2193,8 @@ func CalculateNewActivityStatistics(
 	reporters crypto.ED25519PublicKeySet,
 	currValidators safrole.ValidatorsData,
 	availableWorkReports []block.WorkReport,
+	accumulationStats AccumulationStats,
+	transferStats DeferredTransfersStats,
 ) validator.ActivityStatisticsState {
 	current, last := CalculateNewValidatorStatistics(blk, prevTimeslot, activityStatistics.ValidatorsCurrent, activityStatistics.ValidatorsLast, reporters, currValidators)
 
@@ -2198,7 +2202,7 @@ func CalculateNewActivityStatistics(
 		ValidatorsCurrent: current,
 		ValidatorsLast:    last,
 		Cores:             CalculateNewCoreStatistics(blk, activityStatistics.Cores, availableWorkReports),
-		Services:          CalculateNewServiceStatistics(blk, activityStatistics.Services),
+		Services:          CalculateNewServiceStatistics(blk, accumulationStats, transferStats),
 	}
 }
 
@@ -2318,12 +2322,10 @@ func CalculateNewCoreStatistics(
 // TODO complete service stats, for now this only supports preimage stats.
 func CalculateNewServiceStatistics(
 	blk block.Block,
-	serviceStatistics validator.ServiceStatistics,
+	accumulationStats AccumulationStats,
+	transferStats DeferredTransfersStats,
 ) validator.ServiceStatistics {
-	if serviceStatistics == nil {
-		serviceStatistics = validator.ServiceStatistics{}
-	}
-	newServiceStats := maps.Clone(serviceStatistics)
+	newServiceStats := validator.ServiceStatistics{}
 
 	// Equation 13.11
 	for _, preimage := range blk.Extrinsic.EP {
@@ -2354,6 +2356,28 @@ func CalculateNewServiceStatistics(
 
 			newServiceStats[serviceID] = record
 		}
+	}
+
+	// Equation 13.11
+	// U(I[s], (0, 0))
+	for serviceID, stat := range accumulationStats {
+		record := newServiceStats[serviceID]
+
+		record.AccumulateCount += stat.AccumulateCount
+		record.AccumulateGasUsed += stat.AccumulateGasUsed
+
+		newServiceStats[serviceID] = record
+	}
+
+	// Equation 13.11
+	// U(X[s], (0, 0))
+	for serviceID, stat := range transferStats {
+		record := newServiceStats[serviceID]
+
+		record.OnTransfersCount += stat.OnTransfersCount
+		record.OnTransfersGasUsed += stat.OnTransfersGasUsed
+
+		newServiceStats[serviceID] = record
 	}
 
 	return newServiceStats

--- a/tests/integration/preimages_test.go
+++ b/tests/integration/preimages_test.go
@@ -129,7 +129,6 @@ func TestPreimage(t *testing.T) {
 
 			preServiceState := mapServiceState(t, data.PreState)
 			preimages := mapPreimages(t, data.Input.Preimages)
-			preServiceStats := data.PreState.ServiceStatistics.To()
 
 			newTimeSlot := jamtime.Timeslot(data.Input.Slot)
 			newServiceState, err := statetransition.CalculateIntermediateServiceState(preimages, preServiceState, newTimeSlot)
@@ -143,7 +142,7 @@ func TestPreimage(t *testing.T) {
 				Extrinsic: block.Extrinsic{
 					EP: preimages,
 				},
-			}, preServiceStats)
+			}, statetransition.AccumulationStats{}, statetransition.DeferredTransfersStats{})
 
 			expectedPostServiceState := mapServiceState(t, data.PostState)
 			require.Equal(t, expectedPostServiceState, newServiceState, "State after transition does not match expected state")

--- a/tests/integration/statistics_test.go
+++ b/tests/integration/statistics_test.go
@@ -190,7 +190,8 @@ func TestStatistics(t *testing.T) {
 				reporters.Add(mustStringToHex(reporter))
 			}
 
-			preState.ActivityStatistics = statetransition.CalculateNewActivityStatistics(newBlock, preState.TimeslotIndex, preState.ActivityStatistics, reporters, preState.ValidatorState.CurrentValidators, []block.WorkReport{})
+			preState.ActivityStatistics = statetransition.CalculateNewActivityStatistics(newBlock, preState.TimeslotIndex, preState.ActivityStatistics, reporters, preState.ValidatorState.CurrentValidators,
+				[]block.WorkReport{}, statetransition.AccumulationStats{}, statetransition.DeferredTransfersStats{})
 
 			postState := mapStatisticsState(tc.PostState)
 


### PR DESCRIPTION
Also:
- We don't need to pass in the previous service stats because stats
are always calculated per block.
- Same for core stats.