### PR TITLE
Update disputes v0.6.7

### DIFF
--- a/internal/block/block_test.go
+++ b/internal/block/block_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/eigerco/strawberry/internal/common"
 	"github.com/eigerco/strawberry/internal/crypto"
+	"github.com/eigerco/strawberry/internal/jamtime"
 	"github.com/eigerco/strawberry/internal/testutils"
 	"github.com/eigerco/strawberry/pkg/serialization/codec/jam"
 )
@@ -65,7 +66,7 @@ func Test_BlockEncodeDecode(t *testing.T) {
 	verdicts := []Verdict{
 		{
 			ReportHash: testutils.RandomHash(t),
-			EpochIndex: uint32(1),
+			EpochIndex: jamtime.Epoch(1),
 			Judgements: [common.ValidatorsSuperMajority]Judgement{
 				{
 					IsValid:        true,

--- a/internal/block/dispute.go
+++ b/internal/block/dispute.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/eigerco/strawberry/internal/common"
 	"github.com/eigerco/strawberry/internal/crypto"
+	"github.com/eigerco/strawberry/internal/jamtime"
 )
 
 // DisputeExtrinsic represents the structured input for submitting disputes.
@@ -33,7 +34,7 @@ type DisputeExtrinsic struct {
 // It includes the report hash, epoch index, and a super-majority of judgments.
 type Verdict struct {
 	ReportHash crypto.Hash                               // H, hash of the work report
-	EpochIndex uint32                                    // ⌊τ/E⌋ - N2 (current or prev), epoch index
+	EpochIndex jamtime.Epoch                             // ⌊τ/E⌋ - N2 (current or prev), epoch index
 	Judgements [common.ValidatorsSuperMajority]Judgement // ⟦{⊺,⊥},NV,E⟧⌊2/3V⌋+1
 }
 

--- a/internal/block/dispute.go
+++ b/internal/block/dispute.go
@@ -2,28 +2,49 @@ package block
 
 import (
 	"crypto/ed25519"
+
 	"github.com/eigerco/strawberry/internal/common"
 	"github.com/eigerco/strawberry/internal/crypto"
 )
 
+// DisputeExtrinsic represents the structured input for submitting disputes.
+//
+// This extrinsic is used to finalize the outcome of disputes over work-report validity.
+// It includes:
+//   - Verdicts: Aggregated judgments from auditors determining whether a work-report is valid.
+//   - Culprits: Validators who guaranteed work-reports later found to be invalid.
+//   - Faults: Auditors who issued judgments that contradict the finalized verdict.
+//
+// This extrinsic is included in a block and updates on-chain state:
+//   - Registers final verdicts (valid, invalid, or inconclusive) for specific work-reports.
+//   - Flags misbehaving validators.
+//
+// Equation 10.2(v0.6.7):
+// E_D ≡ (v, c, f)
+// where v ∈ ⟦{H, ⌊τ/E⌋ - N_2, ⟦{⊺, ⊥}, N_V, E⟧_⌊2/3V⌋+1}⟧
+// and c ∈ ⟦⟨H, H_E, E⟩⟧ , f ∈ ⟦⟨H, {⊺, ⊥}, H_E, E⟩⟧
 type DisputeExtrinsic struct {
-	Verdicts []Verdict
-	Culprits []Culprit
-	Faults   []Fault
+	Verdicts []Verdict // Final judgments on work-reports backed by ≥ 2/3 validator signatures
+	Culprits []Culprit // Guarantors of invalid work-reports
+	Faults   []Fault   // Auditors whose judgments were inconsistent with the final verdict
 }
 
+// Verdict represents a collection of judgments made by validators on a work report.
+// It includes the report hash, epoch index, and a super-majority of judgments.
 type Verdict struct {
 	ReportHash crypto.Hash                               // H, hash of the work report
-	EpochIndex uint32                                    // ⌊τ/E⌋ - N2, epoch index
+	EpochIndex uint32                                    // ⌊τ/E⌋ - N2 (current or prev), epoch index
 	Judgements [common.ValidatorsSuperMajority]Judgement // ⟦{⊺,⊥},NV,E⟧⌊2/3V⌋+1
 }
 
+// Culprit represents misbehaving guarantor who guaranteed an invalid work-report
 type Culprit struct {
 	ReportHash                crypto.Hash             // H, hash of the work report
 	ValidatorEd25519PublicKey ed25519.PublicKey       // He
 	Signature                 crypto.Ed25519Signature // E
 }
 
+// Auditor who made incorrect judgment
 type Fault struct {
 	ReportHash                crypto.Hash             // H, hash of the work report
 	IsValid                   bool                    // {⊺,⊥}
@@ -31,20 +52,17 @@ type Fault struct {
 	Signature                 crypto.Ed25519Signature // E
 }
 
-// Judgement represents a single judgment with a signature
+// Judgement is a statement from an auditor that declares whether a given work-report is valid or invalid
 type Judgement struct {
 	IsValid        bool                    // v: {⊺,⊥}
 	ValidatorIndex uint16                  // i: NV
 	Signature      crypto.Ed25519Signature // s: E
 }
 
-// CountPositiveJudgments counts the number of positive judgments in a verdict
-func CountPositiveJudgments(judgments [common.ValidatorsSuperMajority]Judgement) int {
-	count := 0
-	for _, judgment := range judgments {
-		if judgment.IsValid {
-			count++
-		}
-	}
-	return count
+// Equation 10.11(v0.6.7): V is a sequence of (report_hash, vote_count) pairs
+// where vote_count must be exactly one of: 0, ⌊V/3⌋, or ⌊2V/3⌋+1
+// V ∈ ⟦⟨H, {0, ⌊1/3V⌋, ⌊2/3V⌋ + 1}⟩⟧
+type VerdictSummary struct {
+	ReportHash crypto.Hash // H
+	VoteCount  uint16      // Must be 0, V/3, or 2V/3+1
 }

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -8,7 +8,7 @@ const (
 	NumberOfValidators                           = 1023                                                         // (V) The total number of validators
 	AvailabilityThreshold                        = (2 * NumberOfValidators) / 3                                 // Calculate the availability threshold (2/3 V)
 	TotalNumberOfCores                    uint16 = 341                                                          // (C) Total number of cores in the system
-	ValidatorsSuperMajority                      = (2 * NumberOfValidators / 3) + 1                             // 2/3V + 1
+	ValidatorsSuperMajority               uint16 = (2 * NumberOfValidators / 3) + 1                             // 2/3V + 1
 	WorkReportTimeoutPeriod                      = jamtime.Timeslot(5)                                          // U = 5: The period in timeslots after which reported but unavailable work may be replaced.
 	MaxTicketExtrinsicSize                       = 16                                                           // The maximum number of tickets which may be submitted in a single extrinsic.
 	MaxTicketAttempts                            = 2                                                            // N = 2: The number of ticket entries per validator.

--- a/internal/common/constants_integration.go
+++ b/internal/common/constants_integration.go
@@ -8,7 +8,7 @@ const (
 	NumberOfValidators                           = 6
 	AvailabilityThreshold                        = (2 * NumberOfValidators) / 3 // Calculate the availability threshold (2/3 V)
 	TotalNumberOfCores                    uint16 = 2
-	ValidatorsSuperMajority                      = (2 * NumberOfValidators / 3) + 1
+	ValidatorsSuperMajority               uint16 = (2 * NumberOfValidators / 3) + 1
 	WorkReportTimeoutPeriod                      = jamtime.Timeslot(5)
 	MaxTicketExtrinsicSize                       = 3
 	MaxTicketAttempts                            = 3

--- a/internal/disputes/disputes.go
+++ b/internal/disputes/disputes.go
@@ -1,0 +1,381 @@
+package disputes
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"errors"
+
+	"github.com/eigerco/strawberry/internal/block"
+	"github.com/eigerco/strawberry/internal/common"
+	"github.com/eigerco/strawberry/internal/crypto"
+	"github.com/eigerco/strawberry/internal/jamtime"
+	"github.com/eigerco/strawberry/internal/safrole"
+	"github.com/eigerco/strawberry/internal/state"
+	"github.com/eigerco/strawberry/internal/validator"
+	"slices"
+)
+
+const (
+	DisputeVoteBad   uint16 = 0                                       // 0 positive votes - report is bad
+	DisputeVoteWonky uint16 = common.NumberOfValidators / 3           // 1/3 positive votes - report is wonky/unknowable
+	DisputeVoteGood  uint16 = (2 * common.NumberOfValidators / 3) + 1 // 2/3+1 positive votes - report is good
+)
+
+// verifyVerdictSignatures verifies the signatures of all judgments in a verdict
+// Equation 10.3(v0.6.7):
+// ∀(r, a,j) ∈ v,∀(v, i, s) ∈ j : s ∈ Ek[i]e⟨Xv ⌢ r⟩
+func verifyVerdictSignatures(currentTimeslot jamtime.Timeslot, verdict block.Verdict, currentValidators, archivedValidators safrole.ValidatorsData) error {
+	currentEpoch := uint32(currentTimeslot.ToEpoch())
+	validatorSet := currentValidators
+	if verdict.EpochIndex != currentEpoch {
+		validatorSet = archivedValidators
+	}
+
+	for _, judgment := range verdict.Judgements {
+		context := state.SignatureContextValid
+		if !judgment.IsValid {
+			context = state.SignatureContextInvalid
+		}
+
+		message := append([]byte(context), verdict.ReportHash[:]...)
+
+		if !ed25519.Verify(validatorSet[judgment.ValidatorIndex].Ed25519, message, judgment.Signature[:]) {
+			return errors.New("bad signature")
+		}
+	}
+
+	return nil
+}
+
+// isValidatorKeyInCurrentOrPrevEpoch checks if a validator's Ed25519 key exists in either
+// the current or previous epoch's validator set.
+// Equations 10.3, 10.5, 10.6(v0.6.7):
+// - κ represents the current epoch's validator keys (active validator set)
+// - λ represents the previous epoch's validator keys (archived validator set)
+// - Valid signatures must come from validators in κ = {ke | k ∈ λ ∪ κ} ∖ ψo
+// This check is used to validate that judgments, faults, and culprits come from
+// validators who were active in either the current or previous epoch.
+func isValidatorKeyInCurrentOrPrevEpoch(key ed25519.PublicKey, currentValidators, archivedValidators safrole.ValidatorsData) bool {
+	// Check in current validators
+	for _, validator := range currentValidators {
+		if bytes.Equal(validator.Ed25519, key) {
+			return true
+		}
+	}
+	// Check in archived validators
+	for _, validator := range archivedValidators {
+		if bytes.Equal(validator.Ed25519, key) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsKey(slice []ed25519.PublicKey, key ed25519.PublicKey) bool {
+	for _, k := range slice {
+		if bytes.Equal(k, key) {
+			return true
+		}
+	}
+	return false
+}
+
+// CountPositiveJudgements counts the number of positive judgments in a verdict
+func CountPositiveJudgements(v block.Verdict) uint16 {
+	count := uint16(0)
+	for _, judgment := range v.Judgements {
+		if judgment.IsValid {
+			count++
+		}
+	}
+	return count
+}
+
+// validateFault validates a fault proof
+// Equation 10.6(v0.6.7):
+//
+//	∀(r, v, k, s) ∈ f : ⋀ {
+//	  r ∈ ψ'b ⇔ r ∉ ψ'g ⇔ v⊥,
+//	  k ∈ κ,
+//	  s ∈ Ek⟨Xv ⌢ r⟩
+//	}
+func validateFault(fault block.Fault, verdictSummaries []block.VerdictSummary, offendingValidators []ed25519.PublicKey) error {
+	var summary block.VerdictSummary
+	for _, v := range verdictSummaries {
+		if v.ReportHash == fault.ReportHash {
+			summary = v
+			break
+		}
+	}
+
+	// Fault vote should be opposite to verdict
+	// If verdict is all positive, fault vote should be false
+	if fault.IsValid && summary.VoteCount == DisputeVoteGood {
+		return errors.New("fault verdict wrong")
+	}
+	// If verdict is all negative, fault vote should be true
+	if !fault.IsValid && summary.VoteCount == DisputeVoteBad {
+		return errors.New("fault verdict wrong")
+	}
+
+	// Cannot have faults for wonky verdicts - there's no clear "wrong" side
+	if summary.VoteCount == DisputeVoteWonky {
+		return errors.New("fault verdict wrong")
+	}
+
+	// Verify signature
+	context := state.SignatureContextValid
+	if !fault.IsValid {
+		context = state.SignatureContextInvalid
+	}
+	message := append([]byte(context), fault.ReportHash[:]...)
+	if !ed25519.Verify(fault.ValidatorEd25519PublicKey, message, fault.Signature[:]) {
+		return errors.New("bad signature")
+	}
+
+	if containsKey(offendingValidators, fault.ValidatorEd25519PublicKey) {
+		return errors.New("offender already reported")
+	}
+
+	return nil
+}
+
+// validateCulprit validates a culprit
+// Equation 10.5(v0.6.7):
+//
+//	∀(r, k, s) ∈ c : ⋀ {
+//	  r ∈ ψ'b,
+//	  k ∈ κ,
+//	  s ∈ Ek⟨XG ⌢ r⟩
+//	}
+func validateCulprit(culprit block.Culprit, badReports []crypto.Hash, offendingValidators []ed25519.PublicKey) error {
+	// Must be in bad reports
+	if !slices.Contains(badReports, culprit.ReportHash) {
+		return errors.New("culprits verdict not bad")
+	}
+
+	// Verify guarantee signature
+	message := append([]byte(state.SignatureContextGuarantee), culprit.ReportHash[:]...)
+	if !ed25519.Verify(culprit.ValidatorEd25519PublicKey, message, culprit.Signature[:]) {
+		return errors.New("bad signature")
+	}
+
+	if containsKey(offendingValidators, culprit.ValidatorEd25519PublicKey) {
+		return errors.New("offender already reported")
+	}
+
+	return nil
+}
+
+// verifySortedUnique verifies the ordering and uniqueness constraints for disputes extrinsic
+// Equations 10.7, 10.8, 10.10(v0.6.7):
+// - Equation 10.7: v = [r⌣_(r,a,j)∈v] (verdicts ordered by report hash)
+// - Equation 10.8: c = [k⌣_(r,k,s)∈c], f = [k⌣_(r,v,k,s)∈f] (culprits and faults ordered by Ed25519 key)
+// - Equation 10.10: ∀(r,a,j) ∈ v : j = [i⌣_(v,i,s)∈j] (judgments ordered by validator index)
+// All sequences must be strictly ordered with no duplicates to ensure deterministic processing
+func verifySortedUnique(disputes block.DisputeExtrinsic) error {
+	// Check faults are sorted unique
+	for i := 1; i < len(disputes.Faults); i++ {
+		if bytes.Compare(disputes.Faults[i-1].ValidatorEd25519PublicKey, disputes.Faults[i].ValidatorEd25519PublicKey) >= 0 {
+			return errors.New("faults not sorted unique")
+		}
+	}
+	// Check culprits are sorted unique
+	for i := 1; i < len(disputes.Culprits); i++ {
+		if bytes.Compare(disputes.Culprits[i-1].ValidatorEd25519PublicKey, disputes.Culprits[i].ValidatorEd25519PublicKey) >= 0 {
+			return errors.New("culprits not sorted unique")
+		}
+	}
+
+	// Check verdicts are sorted unique
+	for i := 1; i < len(disputes.Verdicts); i++ {
+		if bytes.Compare(disputes.Verdicts[i-1].ReportHash[:], disputes.Verdicts[i].ReportHash[:]) >= 0 {
+			return errors.New("verdicts not sorted unique")
+		}
+	}
+
+	// Check judgements within verdicts are sorted unique
+	for _, verdict := range disputes.Verdicts {
+		for i := 1; i < len(verdict.Judgements); i++ {
+			if verdict.Judgements[i-1].ValidatorIndex >= verdict.Judgements[i].ValidatorIndex {
+				return errors.New("judgements not sorted unique")
+			}
+		}
+	}
+
+	return nil
+}
+
+// verifyNotAlreadyJudged ensures a verdict's report hasn't already been judged
+// Equation 10.9(v0.6.7):
+// {r | (r,a,j) ∈ v} ⊈ ψg ∪ ψb ∪ ψw
+func verifyNotAlreadyJudged(verdict block.Verdict, stateJudgements state.Judgements) error {
+	reportHash := verdict.ReportHash
+	if slices.Contains(stateJudgements.GoodWorkReports, reportHash) ||
+		slices.Contains(stateJudgements.BadWorkReports, reportHash) ||
+		slices.Contains(stateJudgements.WonkyWorkReports, reportHash) {
+		return errors.New("already judged")
+	}
+	return nil
+}
+
+// validateVerdictAndComputeVerdictSummary implements the verdict validation and produces "V" verdict summary:
+// - Equation 10.11: V ∈ ⟦{H, {0, ⌊V/3⌋, ⌊2V/3⌋ + 1}}⟧ (valid vote counts)
+// - Equation 10.12: V = [(r, Σv) | (r,a,j) ∈ v] (sum positive judgments)
+// - Equation 10.13: ∀(r, ⌊2V/3⌋ + 1) ∈ V : ∃(r, ...) ∈ f (good verdicts need faults)
+// - Equation 10.14: ∀(r, 0) ∈ V : |{(r, ...) ∈ c}| ≥ 2 (bad verdicts need 2+ culprits)
+//
+// The function validates that:
+// 1. All validator indices are valid
+// 2. The vote count matches one of three valid thresholds (good/bad/wonky)
+// 3. Good verdicts have at least one fault entry
+// 4. Bad verdicts have at least two culprit entries
+func validateVerdictAndComputeVerdictSummary(v block.Verdict, faults []block.Fault, culprits []block.Culprit) (block.VerdictSummary, error) {
+	for _, j := range v.Judgements {
+		if j.ValidatorIndex >= common.NumberOfValidators {
+			return block.VerdictSummary{}, errors.New("invalid validator index")
+		}
+	}
+	positiveVotes := CountPositiveJudgements(v)
+
+	switch positiveVotes {
+	case DisputeVoteGood:
+		validFaults := 0
+		for _, fault := range faults {
+			if fault.ReportHash != v.ReportHash || fault.IsValid {
+				continue
+			}
+			validFaults++
+		}
+		if validFaults == 0 {
+			return block.VerdictSummary{}, errors.New("not enough faults")
+		}
+	case DisputeVoteBad:
+		matchingCulprits := 0
+		for _, c := range culprits {
+			if c.ReportHash == v.ReportHash {
+				matchingCulprits++
+			}
+		}
+		if matchingCulprits < 2 {
+			return block.VerdictSummary{}, errors.New("not enough culprits")
+		}
+	case DisputeVoteWonky:
+		// Wonky verdicts are valid and should be processed
+	default:
+		return block.VerdictSummary{}, errors.New("bad vote split")
+	}
+
+	return block.VerdictSummary{
+		ReportHash: v.ReportHash,
+		VoteCount:  positiveVotes,
+	}, nil
+}
+
+// ValidateDisputesExtrinsicAndProduceJudgements processes the disputes extrinsic from a block,
+// validates all verdicts, faults, and culprits, and produces an updated judgements state.
+//
+// The disputes system allows validators to collectively judge work-reports as good, bad, or wonky
+// (undecidable). It also tracks misbehaving validators who either guaranteed invalid reports
+// (culprits) or made incorrect judgments (faults).
+//
+// This function ensures all dispute data is valid before updating the on-chain record of
+// judgements and offending validators.
+func ValidateDisputesExtrinsicAndProduceJudgements(prevTimeslot jamtime.Timeslot, disputes block.DisputeExtrinsic, validators validator.ValidatorState, stateJudgements state.Judgements) (state.Judgements, error) {
+	// First, verify that all items in the extrinsic are properly sorted and unique.
+	// This ensures deterministic processing and prevents duplicate entries.
+	if err := verifySortedUnique(disputes); err != nil {
+		return state.Judgements{}, err
+	}
+	// Prepare to collect verdict summaries and track new offending validators
+	summs := make([]block.VerdictSummary, 0, len(disputes.Verdicts))
+	newOffenders := []ed25519.PublicKey{}
+
+	// Clone the existing judgements state to build upon it
+	newJudgements := state.Judgements{
+		GoodWorkReports:     slices.Clone(stateJudgements.GoodWorkReports),
+		BadWorkReports:      slices.Clone(stateJudgements.BadWorkReports),
+		WonkyWorkReports:    slices.Clone(stateJudgements.WonkyWorkReports),
+		OffendingValidators: slices.Clone(stateJudgements.OffendingValidators),
+	}
+
+	// Process each verdict in the disputes extrinsic
+	for _, v := range disputes.Verdicts {
+		// Verify the verdict is from the current or previous epoch only.
+		// Verdicts from future epochs are invalid, and verdicts older than
+		// one epoch are considered stale and rejected.
+		if v.EpochIndex > uint32(prevTimeslot.ToEpoch()) {
+			return state.Judgements{}, errors.New("bad judgement age")
+		}
+		if uint32(prevTimeslot.ToEpoch())-v.EpochIndex > 1 {
+			return state.Judgements{}, errors.New("bad judgement age")
+		}
+
+		// Validate the verdict structure and compute its summary (vote count).
+		// This checks that the verdict has the required number of judgments
+		// (2/3+1 for good, 0 for bad, 1/3 for wonky) and validates related
+		// fault/culprit requirements.
+		verdictSummary, err := validateVerdictAndComputeVerdictSummary(v, disputes.Faults, disputes.Culprits)
+		if err != nil {
+			return state.Judgements{}, err
+		}
+		// Ensure this work-report hasn't already been judged.
+		// Once a report is judged as good, bad, or wonky, it cannot be re-judged.
+		if err := verifyNotAlreadyJudged(v, stateJudgements); err != nil {
+			return state.Judgements{}, err
+		}
+		// Verify all judgment signatures in the verdict are valid and from
+		// validators in the appropriate epoch's validator set.
+		if err := verifyVerdictSignatures(prevTimeslot, v, validators.CurrentValidators, validators.ArchivedValidators); err != nil {
+			return state.Judgements{}, err
+		}
+		summs = append(summs, verdictSummary)
+	}
+
+	// Categorize each verdict's report hash based on the vote outcome
+	for _, s := range summs {
+		switch s.VoteCount {
+		case DisputeVoteGood:
+			newJudgements.GoodWorkReports = append(newJudgements.GoodWorkReports, s.ReportHash)
+		case DisputeVoteBad:
+			newJudgements.BadWorkReports = append(newJudgements.BadWorkReports, s.ReportHash)
+		case DisputeVoteWonky:
+			newJudgements.WonkyWorkReports = append(newJudgements.WonkyWorkReports, s.ReportHash)
+		default:
+			return state.Judgements{}, errors.New("bad vote split")
+		}
+	}
+
+	// Process culprits - validators who guaranteed work-reports that were judged as bad.
+	// These validators signed guarantees for invalid work, which is a punishable offense.
+	for _, c := range disputes.Culprits {
+		// Verify the culprit's guarantee signature and ensure the report was judged bad
+		if err := validateCulprit(c, newJudgements.BadWorkReports, stateJudgements.OffendingValidators); err != nil {
+			return state.Judgements{}, err
+		}
+		// Ensure the culprit was a validator in the current or previous epoch
+		if !isValidatorKeyInCurrentOrPrevEpoch(c.ValidatorEd25519PublicKey, validators.CurrentValidators, validators.ArchivedValidators) {
+			return state.Judgements{}, errors.New("bad guarantor key")
+		}
+		// Add to new offenders list
+		newOffenders = append(newOffenders, c.ValidatorEd25519PublicKey)
+	}
+
+	// Process faults - validators who made judgments that contradict the verdict.
+	for _, f := range disputes.Faults {
+		// Verify the fault's judgment signature and ensure it contradicts the verdict
+		if err := validateFault(f, summs, stateJudgements.OffendingValidators); err != nil {
+			return state.Judgements{}, err
+		}
+		// Ensure the faulty validator was active in the current or previous epoch
+		if !isValidatorKeyInCurrentOrPrevEpoch(f.ValidatorEd25519PublicKey, validators.CurrentValidators, validators.ArchivedValidators) {
+			return state.Judgements{}, errors.New("bad auditor key")
+		}
+		// Add to new offenders list
+		newOffenders = append(newOffenders, f.ValidatorEd25519PublicKey)
+	}
+	// Add all newly identified offending validators to the permanent record
+	newJudgements.OffendingValidators = append(newJudgements.OffendingValidators, newOffenders...)
+
+	return newJudgements, nil
+}

--- a/internal/disputes/disputes.go
+++ b/internal/disputes/disputes.go
@@ -25,7 +25,7 @@ const (
 // Equation 10.3(v0.6.7):
 // ∀(r, a,j) ∈ v,∀(v, i, s) ∈ j : s ∈ Ek[i]e⟨Xv ⌢ r⟩
 func verifyVerdictSignatures(currentTimeslot jamtime.Timeslot, verdict block.Verdict, currentValidators, archivedValidators safrole.ValidatorsData) error {
-	currentEpoch := uint32(currentTimeslot.ToEpoch())
+	currentEpoch := currentTimeslot.ToEpoch()
 	validatorSet := currentValidators
 	if verdict.EpochIndex != currentEpoch {
 		validatorSet = archivedValidators
@@ -304,10 +304,10 @@ func ValidateDisputesExtrinsicAndProduceJudgements(prevTimeslot jamtime.Timeslot
 		// Verify the verdict is from the current or previous epoch only.
 		// Verdicts from future epochs are invalid, and verdicts older than
 		// one epoch are considered stale and rejected.
-		if v.EpochIndex > uint32(prevTimeslot.ToEpoch()) {
+		if v.EpochIndex > prevTimeslot.ToEpoch() {
 			return state.Judgements{}, errors.New("bad judgement age")
 		}
-		if uint32(prevTimeslot.ToEpoch())-v.EpochIndex > 1 {
+		if prevTimeslot.ToEpoch()-v.EpochIndex > 1 {
 			return state.Judgements{}, errors.New("bad judgement age")
 		}
 

--- a/internal/statetransition/state_transition.go
+++ b/internal/statetransition/state_transition.go
@@ -17,6 +17,7 @@ import (
 	"github.com/eigerco/strawberry/internal/common"
 	"github.com/eigerco/strawberry/internal/crypto"
 	"github.com/eigerco/strawberry/internal/crypto/bandersnatch"
+	"github.com/eigerco/strawberry/internal/disputes"
 	"github.com/eigerco/strawberry/internal/jamtime"
 	"github.com/eigerco/strawberry/internal/merkle/binary_tree"
 	"github.com/eigerco/strawberry/internal/merkle/mountain_ranges"
@@ -222,34 +223,53 @@ func CalculateIntermediateServiceState(
 	return newServiceState, nil
 }
 
-// CalculateIntermediateCoreAssignmentsFromExtrinsics Equation 25: ρ† ≺ (ED , ρ)
-func CalculateIntermediateCoreAssignmentsFromExtrinsics(disputes block.DisputeExtrinsic, coreAssignments state.CoreAssignments) state.CoreAssignments {
+// CalculateIntermediateCoreAssignmentsFromExtrinsics Equation 4.12(v0.6.7): ρ† ≺ (ED , ρ)
+// CalculateIntermediateCoreAssignmentsFromExtrinsics processes dispute verdicts to clear
+// work-reports from cores that have been judged as bad or wonky Equation 10.15(v0.6.7):
+//
+//	∀c ∈ NC : ρ†[c] = {
+//	  ∅ if {(H(ρ[c]w), t) ∈ V, t < ⌊2V/3⌋}
+//	  ρ[c] otherwise
+//	}
+//
+// This ensures that work-reports without a 2/3+1 supermajority of positive judgments
+// are removed from their assigned cores before accumulation can occur. This is a critical
+// security mechanism that prevents invalid or disputed work from being accumulated into
+// the chain state.
+func CalculateIntermediateCoreAssignmentsFromExtrinsics(de block.DisputeExtrinsic, coreAssignments state.CoreAssignments) state.CoreAssignments {
 	newAssignments := coreAssignments // Create a copy of the current assignments
 
 	// Process each verdict in the disputes
-	for _, verdict := range disputes.Verdicts {
-		verdictReportHash := verdict.ReportHash
-		positiveJudgments := block.CountPositiveJudgments(verdict.Judgements)
+	for _, v := range de.Verdicts {
+		verdictReportHash := v.ReportHash
+		positiveJudgments := disputes.CountPositiveJudgements(v)
 
-		// If less than 2/3 majority of positive judgments, clear the assignment for matching cores
-		if positiveJudgments < common.ValidatorsSuperMajority {
+		// If less than 2/3+1 supermajority of positive judgments, the work-report is
+		// considered either bad (0 positive) or wonky (1/3 positive), and must be
+		// cleared from its core to prevent accumulation
+		if positiveJudgments < disputes.DisputeVoteGood {
+			// Search all cores to find where this work-report is assigned
 			for c := uint16(0); c < common.TotalNumberOfCores; c++ {
 				if newAssignments[c] == nil {
 					continue
 				}
 
+				// Hash the work-report currently on this core to check if it matches
 				coreReportHash, err := newAssignments[c].WorkReport.Hash()
 				if err != nil {
 					log.Printf("Failed to hash work report on core %d while clearing assignments for verdict with %d/%d positive votes: %v",
-						c, positiveJudgments, common.ValidatorsSuperMajority, err)
+						c, positiveJudgments, disputes.DisputeVoteGood, err)
 					continue
 				}
 
+				// If this core has the disputed work-report, clear it
 				if coreReportHash == verdictReportHash {
 					newAssignments[c] = nil // Clear the assignment
 				}
 			}
 		}
+		// Note: Work-reports with 2/3+1 positive judgments (good) remain on their cores
+		// and can proceed to accumulation
 	}
 
 	return newAssignments
@@ -843,431 +863,19 @@ func addUniqueEdPubKey(slice []ed25519.PublicKey, key ed25519.PublicKey) []ed255
 	return append(slice, key)
 }
 
-// calculateNewJudgements Equation 23: ψ′ ≺ (ED, ψ)
-// Equations 112-115:(v0.4.5)
+// CalculateNewJudgements Equation 4.11(v0.6.7): ψ′ ≺ (ED, ψ)
+// Equations 10.16-10.19(v0.6.7):
 // ψ'g ≡ ψg ∪ {r | {r, ⌊2/3V⌋ + 1} ∈ V}
 // ψ'b ≡ ψb ∪ {r | {r, 0} ∈ V}
 // ψ'w ≡ ψw ∪ {r | {r, ⌊1/3V⌋} ∈ V}
 // ψ'o ≡ ψo ∪ {k | (r, k, s) ∈ c} ∪ {k | (r, v, k, s) ∈ f}
-func CalculateNewJudgements(priorTimeslot jamtime.Timeslot, disputes block.DisputeExtrinsic, stateJudgements state.Judgements, validators validator.ValidatorState) (state.Judgements, error) {
-	if err := verifySortedUnique(disputes); err != nil {
-		return stateJudgements, err
-	}
-
-	if err := verifyAllSignatures(priorTimeslot, disputes, validators); err != nil {
-		return stateJudgements, err
-	}
-
-	if err := verifyNotAlreadyOffending(disputes.Faults, stateJudgements.OffendingValidators); err != nil {
-		return stateJudgements, err
-	}
-
-	if err := verifyNotAlreadyJudged(disputes.Verdicts, stateJudgements); err != nil {
-		return stateJudgements, err
-	}
-
-	newJudgements := copyJudgements(stateJudgements)
-
-	if err := verifyFaults(disputes.Faults, disputes.Verdicts, stateJudgements.OffendingValidators); err != nil {
-		return stateJudgements, err
-	}
-
-	if err := processVerdicts(disputes, &newJudgements); err != nil {
-		return stateJudgements, err
-	}
-
-	if err := processCulprits(disputes.Culprits, disputes.Verdicts, &newJudgements); err != nil {
+func CalculateNewJudgements(prevTimeSlot jamtime.Timeslot, de block.DisputeExtrinsic, stateJudgements state.Judgements, validators validator.ValidatorState) (state.Judgements, error) {
+	newJudgements, err := disputes.ValidateDisputesExtrinsicAndProduceJudgements(prevTimeSlot, de, validators, stateJudgements)
+	if err != nil {
 		return stateJudgements, err
 	}
 
 	return newJudgements, nil
-}
-
-// Equation 101:(v0.4.5)
-// ∀(r, k, s) ∈ c : ⋀{r ∈ ψ'b, k ∈ k, s ∈ Ek⟨XG ⌢ r⟩}
-func verifyNotAlreadyOffending(faults []block.Fault, offendingValidators []ed25519.PublicKey) error {
-	for _, fault := range faults {
-		if containsKey(offendingValidators, fault.ValidatorEd25519PublicKey) {
-			return errors.New("offender already reported")
-		}
-	}
-	return nil
-}
-
-// Equations 103, 104, 106:(v0.4.5)
-// v = [r __ {r, a, j} ∈ v]  (Verdicts must be ordered by report hash)
-// c = [k __ {r, k, s} ∈ c]  (Culprits must be ordered by validator key)
-// f = [k __ {r, v, k, s} ∈ f]  (Faults must be ordered by validator key)
-// ∀(r, a, j) ∈ v : j = [i __ {v, i, s} ∈ j]  (Judgments within verdicts must be ordered by validator index)
-func verifyNotAlreadyJudged(verdicts []block.Verdict, stateJudgements state.Judgements) error {
-	for _, verdict := range verdicts {
-		reportHash := verdict.ReportHash
-		if contains(stateJudgements.GoodWorkReports, reportHash) ||
-			contains(stateJudgements.BadWorkReports, reportHash) ||
-			contains(stateJudgements.WonkyWorkReports, reportHash) {
-			return errors.New("already judged")
-		}
-	}
-	return nil
-}
-
-func copyJudgements(stateJudgements state.Judgements) state.Judgements {
-	newJudgements := state.Judgements{
-		BadWorkReports:      make([]crypto.Hash, len(stateJudgements.BadWorkReports)),
-		GoodWorkReports:     make([]crypto.Hash, len(stateJudgements.GoodWorkReports)),
-		WonkyWorkReports:    make([]crypto.Hash, len(stateJudgements.WonkyWorkReports)),
-		OffendingValidators: make([]ed25519.PublicKey, len(stateJudgements.OffendingValidators)),
-	}
-
-	copy(newJudgements.BadWorkReports, stateJudgements.BadWorkReports)
-	copy(newJudgements.GoodWorkReports, stateJudgements.GoodWorkReports)
-	copy(newJudgements.WonkyWorkReports, stateJudgements.WonkyWorkReports)
-	copy(newJudgements.OffendingValidators, stateJudgements.OffendingValidators)
-
-	return newJudgements
-}
-
-// Equations 109, 110, 111:(v0.4.5)
-// ∀(r, ⌊2/3V⌋ + 1) ∈ V : ∃(r, ...) ∈ f  (For positive verdicts, must have corresponding fault)
-// ∀(r, 0) ∈ V : |{(r, ...) ∈ c}| ≥ 2  (For negative verdicts, must have at least 2 culprits)
-//
-//	∀c ∈ NC : ρ†[c] = {
-//	    ∅ if {(H(ρ[c]w), t) ∈ V, t < ⌊2/3V⌋}
-//	    ρ[c] otherwise
-//	}
-func processVerdicts(disputes block.DisputeExtrinsic, newJudgements *state.Judgements) error {
-	const V = common.NumberOfValidators // Total number of validators
-	twoThirdsPlusOne := (2 * V / 3) + 1 // ⌊2/3V⌋ + 1
-	oneThird := V / 3                   // ⌊1/3V⌋
-
-	for _, verdict := range disputes.Verdicts {
-		positiveJudgments := block.CountPositiveJudgments(verdict.Judgements)
-
-		switch positiveJudgments {
-		case twoThirdsPlusOne:
-			if err := processPositiveVerdict(verdict, disputes.Faults, newJudgements); err != nil {
-				return err
-			}
-
-		case 0:
-			if err := processNegativeVerdict(verdict, disputes.Culprits, newJudgements); err != nil {
-				return err
-			}
-
-		case oneThird:
-			processWonkyVerdict(verdict, newJudgements)
-
-		default:
-			return fmt.Errorf("bad vote split")
-		}
-	}
-
-	return nil
-}
-
-// Equations 109, 110:(v0.4.5)
-// ∀(r, ⌊2/3V⌋ + 1) ∈ V : ∃(r, ...) ∈ f
-func processPositiveVerdict(verdict block.Verdict, faults []block.Fault, newJudgements *state.Judgements) error {
-	validFaults := 0
-	for _, fault := range faults {
-		if fault.ReportHash != verdict.ReportHash || fault.IsValid {
-			continue
-		}
-		validFaults++
-		if !containsKey(newJudgements.OffendingValidators, fault.ValidatorEd25519PublicKey) {
-			newJudgements.OffendingValidators = append(newJudgements.OffendingValidators, fault.ValidatorEd25519PublicKey)
-		}
-	}
-
-	if validFaults == 0 {
-		return errors.New("not enough faults")
-	}
-
-	newJudgements.GoodWorkReports = append(newJudgements.GoodWorkReports, verdict.ReportHash)
-	return nil
-}
-
-// Related to Equation 110:(v0.4.5)
-// ∀(r, 0) ∈ V : |{(r, ...) ∈ c}| ≥ 2
-func processNegativeVerdict(verdict block.Verdict, culprits []block.Culprit, newJudgements *state.Judgements) error {
-	if len(culprits) < 2 {
-		return errors.New("not enough culprits")
-	}
-	newJudgements.BadWorkReports = append(newJudgements.BadWorkReports, verdict.ReportHash)
-	return nil
-}
-
-// Related to Equation 114:(v0.4.5)
-// ψ'w ≡ ψw ∪ {r | {r, ⌊1/3V⌋} ∈ V}
-func processWonkyVerdict(verdict block.Verdict, newJudgements *state.Judgements) {
-	newJudgements.WonkyWorkReports = append(newJudgements.WonkyWorkReports, verdict.ReportHash)
-}
-
-// Equations 101, 102, 104, 105: (v0.4.5)
-// c = [k __ {r, k, s} ∈ c]  (Culprits must be ordered)
-//
-//	∀(r, k, s) ∈ c : ⋀{
-//	    r ∈ ψ'b,  (Report must be in bad reports)
-//	    k ∈ k,    (Key must be valid validator)
-//	    s ∈ Ek⟨XG ⌢ r⟩  (Signature must be valid)
-//	}
-//
-//	∀(r, v, k, s) ∈ f : ⋀{
-//	    r ∈ ψ'b ⇔ r ∉ ψ'g ⇔ v,
-//	    k ∈ k,
-//	    s ∈ Ek⟨Xv ⌢ r⟩
-//	}
-//
-// {r | {r, a, j} ∈ v} ⫰ ψg ∪ ψb ∪ ψw  (Reports must not have been previously judged)
-func processCulprits(culprits []block.Culprit, verdicts []block.Verdict, newJudgements *state.Judgements) error {
-	for _, culprit := range culprits {
-		// Find corresponding verdict
-		var allNegative bool
-		for _, verdict := range verdicts {
-			if verdict.ReportHash == culprit.ReportHash {
-				// Check if all votes are false
-				positiveJudgments := block.CountPositiveJudgments(verdict.Judgements)
-				if positiveJudgments > 0 {
-					return errors.New("bad vote split")
-				}
-				allNegative = true
-				break
-			}
-		}
-		if !allNegative {
-			return errors.New("culprits verdict not bad")
-		}
-	}
-
-	// Process culprits
-	if err := verifyCulprits(culprits, newJudgements.BadWorkReports, newJudgements.OffendingValidators); err != nil {
-		return err
-	}
-
-	for _, culprit := range culprits {
-		if !containsKey(newJudgements.OffendingValidators, culprit.ValidatorEd25519PublicKey) {
-			newJudgements.OffendingValidators = append(newJudgements.OffendingValidators, culprit.ValidatorEd25519PublicKey)
-		}
-	}
-
-	return nil
-}
-
-// Equations 103, 104, 106:
-// v = [r __ {r, a, j} ∈ v]  (Verdicts must be ordered by report hash)
-// c = [k __ {r, k, s} ∈ c]  (Faults must be ordered by validator key)
-// f = [k __ {r, v, k, s} ∈ f]  (Faults must be ordered by validator key)
-// ∀(r, a, j) ∈ v : j = [i __ {v, i, s} ∈ j]  (Judgments within verdicts must be ordered by validator index)
-func verifySortedUnique(disputes block.DisputeExtrinsic) error {
-	// Check faults are sorted unique
-	for i := 1; i < len(disputes.Faults); i++ {
-		if bytes.Compare(disputes.Faults[i-1].ValidatorEd25519PublicKey, disputes.Faults[i].ValidatorEd25519PublicKey) >= 0 {
-			return errors.New("faults not sorted unique")
-		}
-	}
-
-	// Check verdicts are sorted unique
-	for i := 1; i < len(disputes.Verdicts); i++ {
-		if bytes.Compare(disputes.Verdicts[i-1].ReportHash[:], disputes.Verdicts[i].ReportHash[:]) >= 0 {
-			return errors.New("verdicts not sorted unique")
-		}
-	}
-
-	// Check judgements within verdicts are sorted unique
-	for _, verdict := range disputes.Verdicts {
-		for i := 1; i < len(verdict.Judgements); i++ {
-			if verdict.Judgements[i-1].ValidatorIndex >= verdict.Judgements[i].ValidatorIndex {
-				return errors.New("judgements not sorted unique")
-			}
-		}
-	}
-
-	return nil
-}
-
-// Related to Equation 99:(v0.4.5)
-// ∀(r, a, j) ∈ v, ∀(v, i, s) ∈ j : s ∈ Ek[i]e⟨Xv ⌢ r⟩
-func verifyAllSignatures(newTimeslot jamtime.Timeslot, disputes block.DisputeExtrinsic, validators validator.ValidatorState) error {
-	// Verify verdict signatures
-	for _, verdict := range disputes.Verdicts {
-		if err := verifyVerdictSignatures(newTimeslot, verdict, validators.CurrentValidators, validators.ArchivedValidators); err != nil {
-			return err
-		}
-	}
-
-	// Verify culprit signatures
-	for _, culprit := range disputes.Culprits {
-		// Check if the key is in the validator set
-		if !isValidatorKeyInCurrentOrPrevEpoch(culprit.ValidatorEd25519PublicKey,
-			validators.CurrentValidators,
-			validators.ArchivedValidators) {
-			return errors.New("bad guarantor key")
-		}
-		message := append([]byte(state.SignatureContextGuarantee), culprit.ReportHash[:]...)
-		if !ed25519.Verify(culprit.ValidatorEd25519PublicKey, message, culprit.Signature[:]) {
-			return errors.New("bad signature")
-		}
-	}
-
-	// Verify fault signatures
-	for _, fault := range disputes.Faults {
-		// Check if the key is in the validator set
-		if !isValidatorKeyInCurrentOrPrevEpoch(fault.ValidatorEd25519PublicKey,
-			validators.CurrentValidators,
-			validators.ArchivedValidators) {
-			return errors.New("bad auditor key")
-		}
-		context := state.SignatureContextValid
-		if !fault.IsValid {
-			context = state.SignatureContextInvalid
-		}
-		message := append([]byte(context), fault.ReportHash[:]...)
-		if !ed25519.Verify(fault.ValidatorEd25519PublicKey, message, fault.Signature[:]) {
-			return errors.New("bad signature")
-		}
-	}
-
-	return nil
-}
-
-// Related to Equation 99:(v0.4.5)
-// ∀(r, a, j) ∈ v, ∀(v, i, s) ∈ j :
-// s ∈ Ek[i]e⟨Xv ⌢ r⟩ where k = κ if a = ⌊τ/E⌋, λ otherwise
-func verifyVerdictSignatures(newTimeslot jamtime.Timeslot, verdict block.Verdict, currentValidators, archivedValidators safrole.ValidatorsData) error {
-	currentEpoch := uint32(newTimeslot.ToEpoch())
-	validatorSet := currentValidators
-	if verdict.EpochIndex != currentEpoch {
-		validatorSet = archivedValidators
-	}
-
-	// Verify signatures before checking age
-	for _, judgment := range verdict.Judgements {
-		if judgment.ValidatorIndex >= uint16(len(validatorSet)) {
-			return errors.New("invalid validator index")
-		}
-
-		context := state.SignatureContextValid
-		if !judgment.IsValid {
-			context = state.SignatureContextInvalid
-		}
-
-		message := append([]byte(context), verdict.ReportHash[:]...)
-
-		if !ed25519.Verify(validatorSet[judgment.ValidatorIndex].Ed25519, message, judgment.Signature[:]) {
-			return errors.New("bad signature")
-		}
-	}
-	// Age checks come after signature verification
-	if verdict.EpochIndex > currentEpoch {
-		return errors.New("bad judgement age")
-	}
-	if currentEpoch-verdict.EpochIndex > 1 {
-		return errors.New("bad judgement age")
-	}
-
-	return nil
-}
-
-// Related to Equations 101, 102:(v0.4.5)
-// ∀(r, k, s) ∈ c : ⋀{r ∈ ψ'b, k ∈ k, s ∈ Ek⟨XG ⌢ r⟩}
-// ∀(r, v, k, s) ∈ f : ⋀{r ∈ ψ'b ⇔ r ∉ ψ'g ⇔ v, k ∈ k, s ∈ Ek⟨Xv ⌢ r⟩}
-func verifyCulprits(culprits []block.Culprit, badReports []crypto.Hash, offendingValidators []ed25519.PublicKey) error {
-	for i := 1; i < len(culprits); i++ {
-		if bytes.Compare(culprits[i-1].ValidatorEd25519PublicKey, culprits[i].ValidatorEd25519PublicKey) >= 0 {
-			return errors.New("culprits not sorted unique")
-		}
-	}
-	for _, culprit := range culprits {
-		// Verify guarantee signature
-		message := append([]byte(state.SignatureContextGuarantee), culprit.ReportHash[:]...)
-		if !ed25519.Verify(culprit.ValidatorEd25519PublicKey, message, culprit.Signature[:]) {
-			return errors.New("bad signature")
-		}
-		// Must be in bad reports
-		if !contains(badReports, culprit.ReportHash) {
-			return errors.New("culprits verdict not bad")
-		}
-
-		// Must not already be in offending validators
-		if containsKey(offendingValidators, culprit.ValidatorEd25519PublicKey) {
-			return errors.New("offender already reported")
-		}
-	}
-	return nil
-}
-
-// Related to Equations 101, 102:(v0.4.5)
-// ∀(r, k, s) ∈ c : ⋀{r ∈ ψ'b, k ∈ k, s ∈ Ek⟨XG ⌢ r⟩}
-// ∀(r, v, k, s) ∈ f : ⋀{r ∈ ψ'b ⇔ r ∉ ψ'g ⇔ v, k ∈ k, s ∈ Ek⟨Xv ⌢ r⟩}
-func verifyFaults(faults []block.Fault, verdicts []block.Verdict, offendingValidators []ed25519.PublicKey) error {
-	for _, fault := range faults {
-		// Find corresponding verdict
-		var allPositive bool
-		for _, verdict := range verdicts {
-			if verdict.ReportHash == fault.ReportHash {
-				positiveJudgments := block.CountPositiveJudgments(verdict.Judgements)
-				allPositive = positiveJudgments == len(verdict.Judgements)
-				break
-			}
-		}
-
-		// Fault vote should be opposite to verdict
-		// If verdict is all positive, fault vote should be false
-		// If verdict is all negative, fault vote should be true
-		if fault.IsValid == allPositive {
-			return errors.New("fault verdict wrong")
-		}
-
-		// Check that validator isn't already offending
-		if containsKey(offendingValidators, fault.ValidatorEd25519PublicKey) {
-			return errors.New("offender already reported")
-		}
-
-		// Verify signature
-		context := state.SignatureContextValid
-		if !fault.IsValid {
-			context = state.SignatureContextInvalid
-		}
-		message := append([]byte(context), fault.ReportHash[:]...)
-		if !ed25519.Verify(fault.ValidatorEd25519PublicKey, message, fault.Signature[:]) {
-			return errors.New("bad signature")
-		}
-	}
-	return nil
-}
-
-func isValidatorKeyInCurrentOrPrevEpoch(key ed25519.PublicKey, currentValidators, archivedValidators safrole.ValidatorsData) bool {
-	// Check in current validators
-	for _, validator := range currentValidators {
-		if bytes.Equal(validator.Ed25519, key) {
-			return true
-		}
-	}
-	// Check in archived validators
-	for _, validator := range archivedValidators {
-		if bytes.Equal(validator.Ed25519, key) {
-			return true
-		}
-	}
-	return false
-}
-
-func contains(slice []crypto.Hash, item crypto.Hash) bool {
-	for _, hash := range slice {
-		if hash == item {
-			return true
-		}
-	}
-	return false
-}
-
-func containsKey(slice []ed25519.PublicKey, key ed25519.PublicKey) bool {
-	for _, k := range slice {
-		if bytes.Equal(k, key) {
-			return true
-		}
-	}
-	return false
 }
 
 // CalculateNewCoreAssignments updates the core assignments based on new guarantees.

--- a/internal/statetransition/state_transition.go
+++ b/internal/statetransition/state_transition.go
@@ -223,9 +223,9 @@ func CalculateIntermediateServiceState(
 	return newServiceState, nil
 }
 
-// CalculateIntermediateCoreAssignmentsFromExtrinsics Equation 4.12(v0.6.7): ρ† ≺ (ED , ρ)
 // CalculateIntermediateCoreAssignmentsFromExtrinsics processes dispute verdicts to clear
 // work-reports from cores that have been judged as bad or wonky Equation 10.15(v0.6.7):
+// Equation 4.12(v0.6.7): ρ† ≺ (ED , ρ)
 //
 //	∀c ∈ NC : ρ†[c] = {
 //	  ∅ if {(H(ρ[c]w), t) ∈ V, t < ⌊2V/3⌋}

--- a/internal/testutils/json/block.go
+++ b/internal/testutils/json/block.go
@@ -395,7 +395,7 @@ type Disputes struct {
 
 type Verdict struct {
 	Target string        `json:"target"`
-	Age    uint32        `json:"age"`
+	Age    jamtime.Epoch `json:"age"`
 	Votes  []VerdictVote `json:"votes"`
 }
 

--- a/tests/integration/codec_integration_test.go
+++ b/tests/integration/codec_integration_test.go
@@ -572,8 +572,8 @@ type ExpectedAssurances struct {
 
 type ExpectedDisputes struct {
 	Verdicts []struct {
-		Target string `json:"target"`
-		Age    uint32 `json:"age"`
+		Target string        `json:"target"`
+		Age    jamtime.Epoch `json:"age"`
 		Votes  []struct {
 			Vote      bool   `json:"vote"`
 			Index     uint16 `json:"index"`

--- a/tests/integration/disputes_test.go
+++ b/tests/integration/disputes_test.go
@@ -48,9 +48,9 @@ type Judgement struct {
 }
 
 type Verdict struct {
-	ReportHash string      `json:"target"`
-	EpochIndex int         `json:"age"`
-	Judgements []Judgement `json:"votes"`
+	ReportHash string        `json:"target"`
+	EpochIndex jamtime.Epoch `json:"age"`
+	Judgements []Judgement   `json:"votes"`
 }
 
 type Culprit struct {
@@ -231,7 +231,7 @@ func mapVerdicts(verdicts []Verdict) []block.Verdict {
 	for i, verdict := range verdicts {
 		mappedVerdicts[i] = block.Verdict{
 			ReportHash: crypto.Hash(mustStringToHex(verdict.ReportHash)),
-			EpochIndex: uint32(verdict.EpochIndex),
+			EpochIndex: verdict.EpochIndex,
 			Judgements: mapJudgments(verdict.Judgements),
 		}
 	}


### PR DESCRIPTION
Moved most of the logic out from `statetransition` into new package `disputes`. 
Added a new `VerdictSummary` to more accurately follow the GP.
Optimized verifications.
Updated equation comments.