### PR TITLE
Balance calculation updates v0.6.7

### DIFF
--- a/internal/polkavm/host_call/accumulate_functions.go
+++ b/internal/polkavm/host_call/accumulate_functions.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/eigerco/strawberry/internal/polkavm"
 	"github.com/eigerco/strawberry/internal/service"
 	"github.com/eigerco/strawberry/internal/state"
-	"github.com/eigerco/strawberry/internal/state/serialization/statekey"
 	"github.com/eigerco/strawberry/pkg/serialization/codec/jam"
 )
 
@@ -149,7 +148,7 @@ func New(gas Gas, regs Registers, mem Memory, ctxPair AccumulateContextPair) (Ga
 
 	// let a = (c, s ∶ {}, l ∶ {(c, l) ↦ []}, b ∶ at, g, m) if c ≠ ∇
 	account := service.ServiceAccount{
-		Storage: make(map[statekey.StateKey][]byte),
+		Storage: service.NewAccountStorage(),
 		PreimageMeta: map[service.PreImageMetaKey]service.PreimageHistoricalTimeslots{
 			{Hash: codeHash, Length: service.PreimageLength(preimageLength)}: {},
 		},

--- a/internal/polkavm/host_call/accumulate_functions_test.go
+++ b/internal/polkavm/host_call/accumulate_functions_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/eigerco/strawberry/internal/safrole"
 	"github.com/eigerco/strawberry/internal/service"
 	"github.com/eigerco/strawberry/internal/state"
-	"github.com/eigerco/strawberry/internal/state/serialization/statekey"
 	"github.com/eigerco/strawberry/internal/testutils"
 	"github.com/eigerco/strawberry/pkg/serialization/codec/jam"
 )
@@ -183,7 +182,7 @@ func TestAccumulate(t *testing.T) {
 				AccumulationState: state.AccumulationState{
 					ServiceState: service.ServiceState{
 						service.CheckIndex(service.BumpIndex(newServiceID), make(service.ServiceState)): {
-							Storage: make(map[statekey.StateKey][]byte),
+							Storage: service.NewAccountStorage(),
 							PreimageMeta: map[service.PreImageMetaKey]service.PreimageHistoricalTimeslots{
 								{Hash: randomHash, Length: service.PreimageLength(100)}: {},
 							},

--- a/internal/state/serialization/deserialization.go
+++ b/internal/state/serialization/deserialization.go
@@ -170,11 +170,9 @@ func deserializeStorage(state *state.State, sk statekey.StateKey, encodedValue [
 		return fmt.Errorf("deserializing storage: service ID '%v' does not exist", serviceId)
 	}
 
-	if serviceAccount.Storage == nil {
-		serviceAccount.Storage = map[statekey.StateKey][]byte{}
-	}
+	serviceAccount.Storage = service.NewAccountStorage()
 
-	serviceAccount.Storage[sk] = encodedValue
+	serviceAccount.Storage.Set(sk, uint32(len(sk)), encodedValue)
 
 	state.Services[serviceId] = serviceAccount
 

--- a/internal/state/serialization/serialization.go
+++ b/internal/state/serialization/serialization.go
@@ -125,8 +125,8 @@ func serializeServiceAccount(serviceId block.ServiceId, serviceAccount service.S
 	return nil
 }
 
-func serializeStorage(storage map[statekey.StateKey][]byte, serializedState map[statekey.StateKey][]byte) error {
-	for stateKey, value := range storage {
+func serializeStorage(storage service.AccountStorage, serializedState map[statekey.StateKey][]byte) error {
+	for stateKey, value := range storage.Items() {
 
 		// Storage keys are state keys. This allows deserialization
 		// later since state key creation for them is lossy. The PVM code knows

--- a/internal/state/serialization/testutils.go
+++ b/internal/state/serialization/testutils.go
@@ -64,9 +64,11 @@ func RandomStateKey(t *testing.T) statekey.StateKey {
 }
 
 func RandomServiceAccount(t *testing.T) service.ServiceAccount {
+	storage := service.NewAccountStorage()
+	storage.Set(RandomStateKey(t), 10, []byte("data"))
 	preimageData := []byte("preimage data")
 	return service.ServiceAccount{
-		Storage:        map[statekey.StateKey][]byte{RandomStateKey(t): []byte("data")},
+		Storage:        storage,
 		PreimageLookup: map[crypto.Hash][]byte{crypto.HashData(preimageData): preimageData},
 		PreimageMeta: map[service.PreImageMetaKey]service.PreimageHistoricalTimeslots{
 			{Hash: crypto.HashData(preimageData), Length: service.PreimageLength(len(preimageData))}: {testutils.RandomTimeslot()},

--- a/internal/statetransition/accumulate.go
+++ b/internal/statetransition/accumulate.go
@@ -4,11 +4,9 @@ import (
 	"errors"
 	"log"
 
-	"github.com/eigerco/strawberry/internal/jamtime"
-	"github.com/eigerco/strawberry/internal/state/serialization/statekey"
-
 	"github.com/eigerco/strawberry/internal/block"
 	"github.com/eigerco/strawberry/internal/crypto"
+	"github.com/eigerco/strawberry/internal/jamtime"
 	"github.com/eigerco/strawberry/internal/polkavm"
 	"github.com/eigerco/strawberry/internal/polkavm/host_call"
 	"github.com/eigerco/strawberry/internal/polkavm/interpreter"
@@ -78,9 +76,8 @@ func (a *Accumulator) InvokePVM(accState state.AccumulationState, newTime jamtim
 	hostCallFunc := func(hostCall uint64, gasCounter polkavm.Gas, regs polkavm.Registers, mem polkavm.Memory, ctx polkavm.AccumulateContextPair) (polkavm.Gas, polkavm.Registers, polkavm.Memory, polkavm.AccumulateContextPair, error) {
 		// s
 		currentService := accState.ServiceState[serviceIndex]
-		if currentService.Storage == nil {
-			currentService.Storage = make(map[statekey.StateKey][]byte)
-		}
+		currentService.Storage = service.NewAccountStorage()
+
 		if currentService.PreimageLookup == nil {
 			currentService.PreimageLookup = make(map[crypto.Hash][]byte)
 		}

--- a/internal/statetransition/state_transition_test.go
+++ b/internal/statetransition/state_transition_test.go
@@ -143,6 +143,7 @@ func TestCalculateIntermediateServiceState(t *testing.T) {
 func TestCalculateIntermediateServiceStateEmptyPreimages(t *testing.T) {
 	serviceState := service.ServiceState{
 		block.ServiceId(0): {
+			Storage: service.NewAccountStorage(),
 			PreimageLookup: map[crypto.Hash][]byte{
 				{4, 5, 6}: {7, 8, 9},
 			},

--- a/internal/testutils/json/state.go
+++ b/internal/testutils/json/state.go
@@ -395,11 +395,12 @@ type AccountData struct {
 }
 
 func (ad AccountData) To() service.ServiceAccount {
-	storage := map[statekey.StateKey][]byte{}
+	storage := service.NewAccountStorage()
 	if ad.Storage != nil {
 		for k, v := range *ad.Storage {
 			stateKey := hexToBytes(k)
-			storage[statekey.StateKey(stateKey)] = hexToBytes(v)
+			// TODO this is wrong since it uses statekey size, we need to have original key size to produce correct balance results
+			storage.Set(statekey.StateKey(stateKey), uint32(len(stateKey)), hexToBytes(v))
 		}
 	}
 
@@ -434,9 +435,9 @@ func (ad AccountData) To() service.ServiceAccount {
 
 func NewAccountData(account service.ServiceAccount) AccountData {
 	var storage *Storage
-	if len(account.Storage) > 0 {
+	if account.Storage.Len() > 0 {
 		s := Storage{}
-		for sk, blob := range account.Storage {
+		for sk, blob := range account.Storage.Items() {
 			k := bytesToHex(sk[:])
 			s[k] = bytesToHex(blob)
 		}

--- a/internal/work/package_test.go
+++ b/internal/work/package_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/eigerco/strawberry/internal/crypto"
 	"github.com/eigerco/strawberry/internal/jamtime"
 	"github.com/eigerco/strawberry/internal/service"
-	"github.com/eigerco/strawberry/internal/state/serialization/statekey"
 	"github.com/eigerco/strawberry/internal/work"
 )
 
@@ -89,7 +88,7 @@ func Test_ComputeAuthorizerHashes(t *testing.T) {
 
 	h := crypto.HashData(preimage)
 	sa := service.ServiceAccount{
-		Storage:        make(map[statekey.StateKey][]byte),
+		Storage:        service.NewAccountStorage(),
 		PreimageLookup: make(map[crypto.Hash][]byte),
 		PreimageMeta:   make(map[service.PreImageMetaKey]service.PreimageHistoricalTimeslots),
 	}

--- a/tests/integration/accumulate_test.go
+++ b/tests/integration/accumulate_test.go
@@ -321,7 +321,7 @@ func mapAccumulateServices(t *testing.T, accounts []AccumulateServiceAccount) se
 		sa := service.ServiceAccount{
 			PreimageLookup:         make(map[crypto.Hash][]byte),
 			PreimageMeta:           make(map[service.PreImageMetaKey]service.PreimageHistoricalTimeslots),
-			Storage:                make(map[statekey.StateKey][]byte),
+			Storage:                service.NewAccountStorage(),
 			CodeHash:               mapHash(account.Data.Service.CodeHash),
 			Balance:                account.Data.Service.Balance,
 			GasLimitForAccumulator: account.Data.Service.MinItemGas,
@@ -342,7 +342,8 @@ func mapAccumulateServices(t *testing.T, accounts []AccumulateServiceAccount) se
 			// to create the same result and being able to compare the values properly
 			sk, err := statekey.NewStorage(serviceId, crypto.HashData(append(serviceIdBytes, mustStringToHex(storage.Key)...)))
 			require.NoError(t, err)
-			sa.Storage[sk] = mustStringToHex(storage.Value)
+
+			sa.Storage.Set(sk, uint32(len(mustStringToHex(storage.Key))), mustStringToHex(storage.Value))
 		}
 
 		// Skip this test verification, the storage footprint for this service seems to be wrong in the test vector

--- a/tests/integration/json_test.go
+++ b/tests/integration/json_test.go
@@ -6,13 +6,16 @@ import (
 	"os"
 	"testing"
 
-	jsonutils "github.com/eigerco/strawberry/internal/testutils/json"
 	"github.com/stretchr/testify/require"
+
+	jsonutils "github.com/eigerco/strawberry/internal/testutils/json"
 )
 
 // Tests that we can decode a JSON state dump and re-encode it.
 // Dump taken from: https://github.com/jam-duna/jamtestnet
 func TestJSONStateShapshotRestoreDump(t *testing.T) {
+	t.Skip("TODO: update this test when 0.6.7 traces are released")
+
 	jsonDumpBytes, err := os.ReadFile("vectors_community/json/statedump.json")
 	if err != nil {
 		t.Fatalf("Error opening file: %v", err)

--- a/tests/integration/preimages_test.go
+++ b/tests/integration/preimages_test.go
@@ -10,18 +10,18 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/eigerco/strawberry/internal/state/serialization/statekey"
 	"github.com/eigerco/strawberry/internal/store"
 	"github.com/eigerco/strawberry/pkg/db/pebble"
 
 	"github.com/eigerco/strawberry/internal/statetransition"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/eigerco/strawberry/internal/block"
 	"github.com/eigerco/strawberry/internal/crypto"
 	"github.com/eigerco/strawberry/internal/jamtime"
 	"github.com/eigerco/strawberry/internal/service"
 	jsonutils "github.com/eigerco/strawberry/internal/testutils/json"
-	"github.com/stretchr/testify/require"
 )
 
 func ReadPreimageJSONFile(filename string) (*PreimageTestVector, error) {
@@ -159,7 +159,7 @@ func mapServiceState(t *testing.T, state PreimageState) service.ServiceState {
 	for _, account := range state.Accounts {
 		serviceId := block.ServiceId(account.ID)
 		serviceAccount := service.ServiceAccount{
-			Storage:                make(map[statekey.StateKey][]byte),
+			Storage:                service.NewAccountStorage(),
 			PreimageLookup:         make(map[crypto.Hash][]byte),
 			PreimageMeta:           make(map[service.PreImageMetaKey]service.PreimageHistoricalTimeslots),
 			Balance:                1000, // Default values for fields not in test vector

--- a/tests/integration/reports_test.go
+++ b/tests/integration/reports_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/eigerco/strawberry/internal/merkle/mountain_ranges"
-	"github.com/eigerco/strawberry/internal/state/serialization/statekey"
 	"github.com/eigerco/strawberry/internal/store"
 	"github.com/eigerco/strawberry/internal/validator"
 	"github.com/eigerco/strawberry/pkg/db/pebble"
@@ -432,7 +431,7 @@ func mapServices(services []ServiceInfo) service.ServiceState {
 
 	for _, s := range services {
 		serviceState[block.ServiceId(s.ID)] = service.ServiceAccount{
-			Storage:                make(map[statekey.StateKey][]byte),
+			Storage:                service.NewAccountStorage(),
 			PreimageLookup:         make(map[crypto.Hash][]byte),
 			PreimageMeta:           make(map[service.PreImageMetaKey]service.PreimageHistoricalTimeslots),
 			CodeHash:               crypto.Hash(mustStringToHex(s.Data.Service.CodeHash)),


### PR DESCRIPTION
This PR: 
- Updates the account footprint and threshold balance calculations to account for the original key size, along with other formula adjustments introduced in v0.6.7
- Modifies the read and write host calls to avoid hashing storage keys twice
- Skips a JSON test that relies on old GP version