### PR TITLE
Serialization updates for v0.6.7

### DIFF
--- a/internal/state/serialization/deserialization.go
+++ b/internal/state/serialization/deserialization.go
@@ -45,6 +45,7 @@ func DeserializeState(serializedState map[statekey.StateKey][]byte) (state.State
 		{13, &deserializedState.ActivityStatistics},
 		{14, &deserializedState.AccumulationQueue},
 		{15, &deserializedState.AccumulationHistory},
+		{16, &deserializedState.AccumulationOutputLog},
 	}
 
 	for _, field := range basicFields {
@@ -122,23 +123,20 @@ func deserializeService(state *state.State, sk statekey.StateKey, encodedValue [
 	}
 
 	// Deserialize the combined fields (CodeHash, Balance, etc.)
-	var combined struct {
-		CodeHash               crypto.Hash
-		Balance                uint64
-		GasLimitForAccumulator uint64
-		GasLimitOnTransfer     uint64
-		FootprintSize          uint64
-		FootprintItems         uint32
-	}
-	if err := jam.Unmarshal(encodedValue, &combined); err != nil {
+	encodedServiceAccount := encodedServiceAccount{}
+	if err := jam.Unmarshal(encodedValue, &encodedServiceAccount); err != nil {
 		return fmt.Errorf("deserialize service: error unmarshalling: %w", err)
 	}
 
 	serviceAccount := service.ServiceAccount{
-		CodeHash:               combined.CodeHash,
-		Balance:                combined.Balance,
-		GasLimitForAccumulator: combined.GasLimitForAccumulator,
-		GasLimitOnTransfer:     combined.GasLimitOnTransfer,
+		CodeHash:                       encodedServiceAccount.CodeHash,
+		Balance:                        encodedServiceAccount.Balance,
+		GasLimitForAccumulator:         encodedServiceAccount.GasLimitForAccumulator,
+		GasLimitOnTransfer:             encodedServiceAccount.GasLimitOnTransfer,
+		GratisStorageOffset:            encodedServiceAccount.GratisStorageOffset,
+		CreationTimeslot:               encodedServiceAccount.CreationTimeslot,
+		MostRecentAccumulationTimeslot: encodedServiceAccount.MostRecentAccumulationTimeslot,
+		ParentService:                  encodedServiceAccount.ParentService,
 	}
 
 	state.Services[serviceId] = serviceAccount

--- a/internal/state/serialization/serialization_test.go
+++ b/internal/state/serialization/serialization_test.go
@@ -40,6 +40,10 @@ func TestSerializeState(t *testing.T) {
 		assert.Equal(t, originalService.Balance, decodedService.Balance)
 		assert.Equal(t, originalService.GasLimitForAccumulator, decodedService.GasLimitForAccumulator)
 		assert.Equal(t, originalService.GasLimitOnTransfer, decodedService.GasLimitOnTransfer)
+		assert.Equal(t, originalService.GratisStorageOffset, decodedService.GratisStorageOffset)
+		assert.Equal(t, originalService.CreationTimeslot, decodedService.CreationTimeslot)
+		assert.Equal(t, originalService.MostRecentAccumulationTimeslot, decodedService.MostRecentAccumulationTimeslot)
+		assert.Equal(t, originalService.ParentService, decodedService.ParentService)
 	}
 
 	// Check for extra services in decoded state
@@ -58,6 +62,9 @@ func TestSerializeState(t *testing.T) {
 	// Compare Accumulation Queue and History
 	assert.Equal(t, state.AccumulationQueue, decodedState.AccumulationQueue, "AccumulationQueue mismatch")
 	assert.Equal(t, state.AccumulationHistory, decodedState.AccumulationHistory, "AccumulationHistory mismatch")
+
+	// Compare Accumulation Output Log
+	assert.Equal(t, state.AccumulationOutputLog, decodedState.AccumulationOutputLog, "AccumulationOutputLog mismatch")
 }
 
 func TestSerializeSafroleState(t *testing.T) {
@@ -270,16 +277,4 @@ func TestSerializeStateServices(t *testing.T) {
 		assert.Contains(t, serializedState, hashKey)
 		assert.NotEmpty(t, serializedState[hashKey])
 	}
-}
-
-// TestCombineEncoded verifies that combining multiple encoded fields works as expected.
-func TestCombineEncoded(t *testing.T) {
-	field1 := []byte{0x01, 0x02}
-	field2 := []byte{0x03, 0x04}
-
-	// Combine the fields
-	combined := combineEncoded(field1, field2)
-
-	// Verify the combined result
-	assert.Equal(t, []byte{0x01, 0x02, 0x03, 0x04}, combined)
 }

--- a/internal/state/serialization/testutils.go
+++ b/internal/state/serialization/testutils.go
@@ -73,10 +73,14 @@ func RandomServiceAccount(t *testing.T) service.ServiceAccount {
 		PreimageMeta: map[service.PreImageMetaKey]service.PreimageHistoricalTimeslots{
 			{Hash: crypto.HashData(preimageData), Length: service.PreimageLength(len(preimageData))}: {testutils.RandomTimeslot()},
 		},
-		CodeHash:               testutils.RandomHash(t),
-		Balance:                testutils.RandomUint64(),
-		GasLimitForAccumulator: testutils.RandomUint64(),
-		GasLimitOnTransfer:     testutils.RandomUint64(),
+		CodeHash:                       testutils.RandomHash(t),
+		Balance:                        testutils.RandomUint64(),
+		GasLimitForAccumulator:         testutils.RandomUint64(),
+		GasLimitOnTransfer:             testutils.RandomUint64(),
+		GratisStorageOffset:            testutils.RandomUint64(),
+		CreationTimeslot:               testutils.RandomTimeslot(),
+		MostRecentAccumulationTimeslot: testutils.RandomTimeslot(),
+		ParentService:                  block.ServiceId(testutils.RandomUint32()),
 	}
 }
 
@@ -298,6 +302,18 @@ func RandomSafroleStateWithEpochKeys(t *testing.T) safrole.State {
 	}
 }
 
+func RandomAccumulationOutputLog(t *testing.T, maxSize int) state.AccumulationOutputLog {
+	accumulationOutputLog := state.AccumulationOutputLog{}
+	numEntries := testutils.RandomUint32()%uint32(maxSize) + 1
+	for i := 0; i < int(numEntries); i++ {
+		accumulationOutputLog = append(accumulationOutputLog, state.ServiceHashPair{
+			ServiceId: block.ServiceId(testutils.RandomUint32()),
+			Hash:      testutils.RandomHash(t),
+		})
+	}
+	return accumulationOutputLog
+}
+
 func RandomState(t *testing.T) state.State {
 	services := make(service.ServiceState)
 	for i := 0; i < 10; i++ {
@@ -319,5 +335,6 @@ func RandomState(t *testing.T) state.State {
 		ActivityStatistics:       RandomValidatorStatisticsState(),
 		AccumulationQueue:        RandomAccumulationQueue(t),
 		AccumulationHistory:      RandomAccumulationHistory(t),
+		AccumulationOutputLog:    RandomAccumulationOutputLog(t, 10),
 	}
 }


### PR DESCRIPTION
- Serialize the new accumulation output log state element.
- Serialize new service account fields, also refactor to rather use a modified struct for encoding/decoding.
- Update tests.
- Recent history is fine like it is.
- The serialization format for priviledged services is unknown right now and needs to be addressed with a future GP update.

State key updates will be dealt with in a subsequent PR.