### PR TITLE
Update state keys 0.6.7

### DIFF
--- a/internal/polkavm/host_call/general_functions.go
+++ b/internal/polkavm/host_call/general_functions.go
@@ -347,7 +347,7 @@ func Read(gas polkavm.Gas, regs polkavm.Registers, mem polkavm.Memory, s service
 
 	// Compute the hash H(keyData) and create a state key from it to use
 	// as the storage key.
-	k, err := statekey.NewStorage(ss, crypto.HashData(keyData))
+	k, err := statekey.NewStorage(ss, keyData)
 	if err != nil {
 		return gas, regs, mem, polkavm.ErrPanicf(err.Error())
 	}
@@ -384,7 +384,7 @@ func Write(gas polkavm.Gas, regs polkavm.Registers, mem polkavm.Memory, s servic
 		return gas, regs, mem, s, polkavm.ErrPanicf(err.Error())
 	}
 
-	k, err := statekey.NewStorage(serviceId, crypto.HashData(keyData))
+	k, err := statekey.NewStorage(serviceId, keyData)
 	if err != nil {
 		return gas, regs, mem, s, polkavm.ErrPanicf(err.Error())
 	}

--- a/internal/polkavm/host_call/general_functions_test.go
+++ b/internal/polkavm/host_call/general_functions_test.go
@@ -396,7 +396,7 @@ func TestRead(t *testing.T) {
 	keyData := []byte("key_to_read")
 	value := []byte("value_to_read")
 
-	k, err := statekey.NewStorage(serviceId, crypto.HashData(keyData))
+	k, err := statekey.NewStorage(serviceId, keyData)
 	require.NoError(t, err)
 
 	storage := service.NewAccountStorage()
@@ -452,7 +452,7 @@ func TestWrite(t *testing.T) {
 	keyData := []byte("key_to_write")
 	value := []byte("value_to_write")
 
-	k, err := statekey.NewStorage(serviceId, crypto.HashData(keyData))
+	k, err := statekey.NewStorage(serviceId, keyData)
 	require.NoError(t, err)
 
 	storage := service.NewAccountStorage()

--- a/internal/state/serialization/statekey/statekey.go
+++ b/internal/state/serialization/statekey/statekey.go
@@ -22,12 +22,8 @@ const (
 // The output of the state key constructor function.
 type StateKey [31]byte
 
-// The hash component of the state key constructor function.
-// See equation D.1 in the graypaper 0.6.6
-type HashComponent [27]byte
-
 // First arity of the stake-key constructor function
-// See equation D.1 in the graypaper 0.6.6
+// See equation D.1 in the graypaper 0.6.7
 func NewBasic(i uint8) StateKey {
 	var result StateKey
 
@@ -39,7 +35,7 @@ func NewBasic(i uint8) StateKey {
 }
 
 // Second arity of the stake-key constructor function, (uint8, N_S)
-// See equation D.1 in the graypaper v0.6.6
+// See equation D.1 in the graypaper v0.6.7
 func NewService(s block.ServiceId) (StateKey, error) {
 	encodedServiceId, err := jam.Marshal(s)
 	if err != nil {
@@ -60,77 +56,79 @@ func NewService(s block.ServiceId) (StateKey, error) {
 	return result, nil
 }
 
-// Last airity of the stake-key constructor function, (N_S, Y_27)
-// See equation D.1 in the graypaper v0.6.6
-func NewServiceDict(s block.ServiceId, h HashComponent) (StateKey, error) {
+// Last airity of the stake-key constructor function, (N_S, Y)
+// See equation D.1 in the graypaper v0.6.7
+func NewServiceDict(s block.ServiceId, hashComponent []byte) (StateKey, error) {
 	encodedServiceId, err := jam.Marshal(s)
 	if err != nil {
 		return StateKey{}, err
 	}
+
+	hash := crypto.HashData(hashComponent)
 
 	var result StateKey
 
 	// Interleave the first 4 bytes of encodedServiceId with the first 4 bytes of h
 	// Interleave bytes from encodedServiceId and h
 	result[0] = encodedServiceId[0]
-	result[1] = h[0]
+	result[1] = hash[0]
 	result[2] = encodedServiceId[1]
-	result[3] = h[1]
+	result[3] = hash[1]
 	result[4] = encodedServiceId[2]
-	result[5] = h[2]
+	result[5] = hash[2]
 	result[6] = encodedServiceId[3]
-	result[7] = h[3]
+	result[7] = hash[3]
 
 	// Append the rest of h to the result
-	copy(result[8:], h[4:])
+	copy(result[8:], hash[4:])
 
 	return result, nil
 }
 
 // Create a new storage state key.
-// ∀(s ↦ a) ∈ δ, (k ↦ v) ∈ as ∶ C(s, E4(2^32 − 1) ⌢ k_0...23)
-// See equation D.2 in the graypaper v0.6.6
-func NewStorage(serviceId block.ServiceId, hash crypto.Hash) (StateKey, error) {
+// ∀(s ↦ a) ∈ δ, (k ↦ v) ∈ as ∶ C(s, E4(2^32 − 1) ⌢ k)
+// See equation D.2 in the graypaper v0.6.7
+func NewStorage(serviceId block.ServiceId, originalKey []byte) (StateKey, error) {
 	hashIndex, err := jam.Marshal(HashStorageIndex)
 	if err != nil {
 		return StateKey{}, err
 	}
 
-	var hashComponent HashComponent
+	hashComponent := make([]byte, len(hashIndex)+len(originalKey))
 	copy(hashComponent[:4], hashIndex)
-	copy(hashComponent[4:], hash[:24])
+	copy(hashComponent[4:], originalKey)
 
 	return NewServiceDict(serviceId, hashComponent)
 }
 
 // Create a new preimage state key.
-// ∀(s ↦ a) ∈ δ, (h ↦ p) ∈ ap ∶ C(s, E4(2^32 −2) ⌢ k_1...24)
-// See equation D.2 in the graypaper v0.6.6
-func NewPreimageLookup(serviceId block.ServiceId, hash crypto.Hash) (StateKey, error) {
+// ∀(s ↦ a) ∈ δ, (h ↦ p) ∈ ap ∶ C(s, E4(2^32 −2) ⌢ h)
+// See equation D.2 in the graypaper v0.6.7
+func NewPreimageLookup(serviceId block.ServiceId, originalHash crypto.Hash) (StateKey, error) {
 	hashIndex, err := jam.Marshal(HashPreimageLookupIndex)
 	if err != nil {
 		return StateKey{}, err
 	}
 
-	var hashComponent HashComponent
+	hashComponent := make([]byte, len(hashIndex)+len(originalHash))
 	copy(hashComponent[:4], hashIndex)
-	copy(hashComponent[4:], hash[1:25])
+	copy(hashComponent[4:], originalHash[:])
 
 	return NewServiceDict(serviceId, hashComponent)
 }
 
 // Create a new preimage state key.
-// ∀(s ↦ a) ∈ δ, ((h,l) ↦ t) ∈ al ∶ C(s, E4(l) ⌢ H(h)_2...25)
-// See equation D.2 in the graypaper v0.6.6
-func NewPreimageMeta(serviceId block.ServiceId, hash crypto.Hash, length uint32) (StateKey, error) {
-	encodedLength, err := jam.Marshal(length)
+// ∀(s ↦ a) ∈ δ, ((h,l) ↦ t) ∈ al ∶ C(s, E4(l) ⌢ h)
+// See equation D.2 in the graypaper v0.6.7
+func NewPreimageMeta(serviceId block.ServiceId, originalHash crypto.Hash, originalLength uint32) (StateKey, error) {
+	encodedLength, err := jam.Marshal(originalLength)
 	if err != nil {
 		return StateKey{}, err
 	}
-	hashedHash := crypto.HashData(hash[:])
-	var hashComponent HashComponent
+
+	hashComponent := make([]byte, len(encodedLength)+len(originalHash))
 	copy(hashComponent[:4], encodedLength)
-	copy(hashComponent[4:], hashedHash[2:26])
+	copy(hashComponent[4:], originalHash[:])
 
 	return NewServiceDict(serviceId, hashComponent)
 }
@@ -169,37 +167,6 @@ func (s StateKey) IsServiceKey() bool {
 	return true
 }
 
-// Checks if the given state key is a storage key of the format: [n0, 0xFF, n1, 0xFF, n2, 0xFF, n3, 0xFF, h4, h5,...]
-// Where n is the service ID (uint32) little endian encoded, and h is the hash component.
-func (s StateKey) IsStorageKey() (bool, error) {
-	// The preimage lookup keys hash component starts with max(uint32)
-	// little endian encoded, which is 0xFFFFFFFF. This is interleaved with the
-	// service ID.
-	encodedHashIndex := []byte{s[1], s[3], s[5], s[7]}
-	var index uint32
-	if err := jam.Unmarshal(encodedHashIndex, &index); err != nil {
-		return false, err
-	}
-
-	return index == HashStorageIndex, nil
-
-}
-
-// Checks if the given state key is a preimage lookup key of the format: [n0, 0xFE, n1, 0xFF, n2, 0xFF, n3, 0xFF, h4, h5,...]
-// Where n is the service ID (uint32) little endian encoded, and h is the hash component.
-func (s StateKey) IsPreimageLookupKey() (bool, error) {
-	// The preimage lookup keys hash component starts with max(uint32) - 1
-	// little endian encoded, which is 0xFEFFFFFF. This is interleaved with the
-	// service ID.
-	encodedHashIndex := []byte{s[1], s[3], s[5], s[7]}
-	var index uint32
-	if err := jam.Unmarshal(encodedHashIndex, &index); err != nil {
-		return false, err
-	}
-
-	return index == HashPreimageLookupIndex, nil
-}
-
 // Extracts the chapter and service ID components from a state key of airty 2.
 // State key is the format: [i, n0, 0, n1, 0, n2, 0, n3, 0, 0,...]
 // where i is an uint8, and n is the service ID (uint32) little endian encoded.
@@ -228,7 +195,7 @@ func (s StateKey) ExtractChapterServiceID() (uint8,
 // Extracts the service ID and hash components from a state key of airty 3.
 // The state key is the format: [n0, h0, n1, h1, n2, h2, n3, h3, h4, h5,...]
 // Where n is the server ID uint32 little endian encoded, and h is the hash component.
-func (s StateKey) ExtractServiceIDHash() (block.ServiceId, HashComponent, error) {
+func (s StateKey) ExtractServiceIDHash() (block.ServiceId, []byte, error) {
 	encodedServiceId := []byte{
 		s[0],
 		s[2],
@@ -238,10 +205,10 @@ func (s StateKey) ExtractServiceIDHash() (block.ServiceId, HashComponent, error)
 
 	var serviceId block.ServiceId
 	if err := jam.Unmarshal(encodedServiceId, &serviceId); err != nil {
-		return 0, HashComponent{}, err
+		return 0, []byte{}, err
 	}
 
-	hash := HashComponent{}
+	hash := []byte{}
 	hash[0] = s[1]
 	hash[1] = s[3]
 	hash[2] = s[5]

--- a/internal/state/serialization/statekey/statekey_test.go
+++ b/internal/state/serialization/statekey/statekey_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/eigerco/strawberry/internal/block"
+	"github.com/eigerco/strawberry/internal/crypto"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -73,17 +74,18 @@ func TestNewService(t *testing.T) {
 // TestNewServiceDict verifies that the interleaving function works as expected.
 func TestNewServiceDict(t *testing.T) {
 	serviceId := block.ServiceId(1234)
-	hash := HashComponent{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	hashComponent := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
 
 	// Get encoded service ID for verification
 	encodedServiceId, err := jam.Marshal(serviceId)
 	require.NoError(t, err)
 
 	// Generate the interleaved state key
-	stateKey, err := NewServiceDict(serviceId, hash)
+	stateKey, err := NewServiceDict(serviceId, hashComponent)
 	require.NoError(t, err)
 
-	// Verify that the first 8 bytes are interleaved between serviceId and hash
+	// Verify that the first 8 bytes are interleaved between serviceId and the hash of the hash component
+	hash := crypto.HashData(hashComponent)
 	assert.Equal(t, encodedServiceId[0], stateKey[0])
 	assert.Equal(t, hash[0], stateKey[1])
 	assert.Equal(t, encodedServiceId[1], stateKey[2])

--- a/tests/integration/accumulate_test.go
+++ b/tests/integration/accumulate_test.go
@@ -340,7 +340,7 @@ func mapAccumulateServices(t *testing.T, accounts []AccumulateServiceAccount) se
 			// our code however implements the storage keys correctly as the output of C not the raw value
 			// this creates a discrepancy which fails the tests, so we use the same logic here
 			// to create the same result and being able to compare the values properly
-			sk, err := statekey.NewStorage(serviceId, crypto.HashData(append(serviceIdBytes, mustStringToHex(storage.Key)...)))
+			sk, err := statekey.NewStorage(serviceId, append(serviceIdBytes, mustStringToHex(storage.Key)...))
 			require.NoError(t, err)
 
 			sa.Storage.Set(sk, uint32(len(mustStringToHex(storage.Key))), mustStringToHex(storage.Value))


### PR DESCRIPTION
The last airity for the state key constructor function has changed. We now do the key hashing inside this function, and the state serialisation function merely passes the data to hash.

Because of this we can no longer tell the difference between storage state keys and preimage meta keys anymore. The assumption now is that the host shouldn't need to care how the keys are stored, as long as the underlying host calls can read and write their data.

It's implied that all service dictionary keys should be stored in a single map or KV DB. Each host call would know how to access it's key and value.

So all functionality related to figuring out which type of service dictionary key a given state key is has been removed. We can no longer deserialize service dictionaries.

We will have to revisit this once we refactor the three service dictionary maps into a single map of state key -> bytes.

Also
- The last airty of the state constructor function now takes plain bytes, so a special HashComponent type is no longer needed.