### PR TITLE
Deep copy recent history

### DIFF
--- a/internal/state/block.go
+++ b/internal/state/block.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"maps"
+
 	"github.com/eigerco/strawberry/internal/crypto"
 )
 
@@ -10,6 +12,28 @@ type RecentHistory struct {
 	BlockHistory []BlockState
 	// βB, a merkle mountain range of all accumulation results . Equation 7.3
 	AccumulationOutputLog []*crypto.Hash
+}
+
+// Clone returns a deep copy of the RecentHistory.
+func (r RecentHistory) Clone() RecentHistory {
+	blockHistory := make([]BlockState, len(r.BlockHistory))
+	for i, blockState := range r.BlockHistory {
+		blockHistory[i] = blockState.Clone()
+	}
+
+	accumulationOutputLog := make([]*crypto.Hash, len(r.AccumulationOutputLog))
+	for i, hash := range r.AccumulationOutputLog {
+		if hash == nil {
+			continue
+		}
+		clonedHash := *hash
+		accumulationOutputLog[i] = &clonedHash
+	}
+
+	return RecentHistory{
+		BlockHistory:          blockHistory,
+		AccumulationOutputLog: accumulationOutputLog,
+	}
 }
 
 // BlockState represents the details of the most recent blocks.
@@ -22,4 +46,10 @@ type BlockState struct {
 	StateRoot crypto.Hash
 	// Work-reports included on this block, a map of work package hash to segment-root (p)
 	Reported map[crypto.Hash]crypto.Hash
+}
+
+// Clone returns a deep copy of the BlockState.
+func (b BlockState) Clone() BlockState {
+	b.Reported = maps.Clone(b.Reported)
+	return b
 }

--- a/internal/statetransition/state_transition.go
+++ b/internal/statetransition/state_transition.go
@@ -350,8 +350,7 @@ func CalculateNewTimeState(header block.Header) jamtime.Timeslot {
 // Computes the intermediate recent history.
 func CalculateIntermediateRecentHistory(header block.Header, priorRecentHistory state.RecentHistory) state.RecentHistory {
 
-	// TODO deep copy
-	intermediateRecentHistory := priorRecentHistory
+	intermediateRecentHistory := priorRecentHistory.Clone()
 
 	// Equation 7.5: β†[SβS − 1]s = Hr
 	if len(intermediateRecentHistory.BlockHistory) > 0 {
@@ -407,8 +406,7 @@ func UpdateRecentHistory(
 	workPackageMapping map[crypto.Hash]crypto.Hash,
 	intermediateRecentHistory state.RecentHistory) (state.RecentHistory, error) {
 
-	// TODO deep copy
-	newRecentHistory := intermediateRecentHistory
+	newRecentHistory := intermediateRecentHistory.Clone()
 
 	mountainRange := mountain_ranges.New()
 


### PR DESCRIPTION
- Add a Clone method to RecentHistory.
- Use this to deep copy recent history during state transitions.