### PR TITLE
Block header verification

### DIFF
--- a/internal/statetransition/block.go
+++ b/internal/statetransition/block.go
@@ -1,0 +1,125 @@
+package statetransition
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/eigerco/strawberry/internal/block"
+	"github.com/eigerco/strawberry/internal/state"
+	"github.com/eigerco/strawberry/internal/state/merkle"
+	"github.com/eigerco/strawberry/internal/store"
+	"github.com/eigerco/strawberry/internal/validator"
+)
+
+// VerifyBlockHeaderBasic verifies header fields which are verifiable with just
+// the prior state:
+// - The timeslot
+// - The prior state root
+// - The extrinsic hash
+// The trie database must be passed in produce the merkle root of the state.
+// GP v0.7.0
+func VerifyBlockHeaderBasic(priorState *state.State, block block.Block, trie *store.Trie) error {
+	// Timeslot validation. Equation 5.7
+	// P(H)_T < H_T ∧ H_T ⋅ P ≤ T
+	if block.Header.TimeSlotIndex.IsInFuture() {
+		return errors.New("timeslot is in the future")
+	}
+	if priorState.TimeslotIndex >= block.Header.TimeSlotIndex {
+		return errors.New("timeslot must be greater than the prior state's timeslot")
+	}
+
+	// State root validation. Equation 5.8
+	//  H_R ≡ M_σ(σ)
+	expectedPriorStateRoot, err := merkle.MerklizeState(*priorState, trie)
+	if err != nil {
+		return fmt.Errorf("failed to merklize state: %w", err)
+	}
+	if block.Header.PriorStateRoot != expectedPriorStateRoot {
+		return fmt.Errorf("invalid prior state root: %x", expectedPriorStateRoot)
+	}
+
+	// Check extrinsic hash. Equation 5.4
+	// H_X ≡ H(E(H#(a)))
+	expectedExtrinsicsHash, err := block.Extrinsic.Hash()
+	if err != nil {
+		return fmt.Errorf("failed to hash extrinsics: %w", err)
+	}
+	if block.Header.ExtrinsicHash != expectedExtrinsicsHash {
+		return fmt.Errorf("invalid extrinsics hash: %x", expectedExtrinsicsHash)
+	}
+
+	return nil
+}
+
+// VerifyBlockHeaderSafrole verifies the SAFROLE related fields of the block header:
+// - The epoch marker
+// - The winning ticket marker.
+// - The block seal and vrf signatures.
+// The validatorState should be the posterior SAFROLE state, this function is expected to be used after UpdateSafroleState has been run.
+// GP v0.7.0
+func VerifyBlockHeaderSafrole(validatorState validator.ValidatorState, output SafroleOutput, block block.Block) error {
+	// Check the epoch marker. Equation 6.27
+	// H_E ≡ (η_0, η_1, [(k_b, k_e) | k <− γ′_P ]) if e′ > e,  ∅ otherwise.
+	if output.EpochMark == nil {
+		// The expected epoch marker is not set, so the header epoch marker
+		// shouldn't be either.
+		if block.Header.EpochMarker != nil {
+			return errors.New("epoch marker is set, but should be nil")
+		}
+	} else {
+		// The expected epoch marker is set, so the header epoch marker should
+		// be set and be valid.
+		if block.Header.EpochMarker == nil {
+			return errors.New("epoch marker is nil, but should be set")
+		}
+
+		if block.Header.EpochMarker.Entropy != output.EpochMark.Entropy {
+			return errors.New("epoch marker entropy is invalid")
+		}
+
+		if block.Header.EpochMarker.TicketsEntropy != output.EpochMark.TicketsEntropy {
+			return errors.New("epoch marker tickets entropy is invalid")
+		}
+
+		for i, vk := range output.EpochMark.Keys {
+			if block.Header.EpochMarker.Keys[i].Bandersnatch != vk.Bandersnatch {
+				return errors.New("epoch marker bandersnatch key is invalid")
+			}
+			if !block.Header.EpochMarker.Keys[i].Ed25519.Equal(vk.Ed25519) {
+				return errors.New("epoch marker ed25519 key is invalid")
+			}
+		}
+	}
+
+	// Check winning ticket marker. Equation 6.28
+	// H_W = Z(γ_A) if e′ = e ∧ m < Y ≤ m′ ∧ |γ_A| = E, ∅ otherwise
+	if output.WinningTicketMark == nil {
+		// The expected winning ticket marker is not set, so the header winning
+		// ticket marker shouldn't be set either.
+		if block.Header.WinningTicketsMarker != nil {
+			return errors.New("winning ticket marker is set, but should be nil")
+		}
+	} else {
+		// The expected winning ticket marker is set, so the header winning
+		// ticket marker should be set and valid.
+		if block.Header.WinningTicketsMarker == nil {
+			return errors.New("winning ticket marker is nil, but should be set")
+		}
+		if *block.Header.WinningTicketsMarker != *output.WinningTicketMark {
+			return errors.New("winning ticket marker is invalid")
+		}
+
+	}
+
+	// Verify the block seal and VRF signatures. Equations 6.15 - 6.20
+	// Equations for this are more complex, refer directly to the GP.
+	ok, err := state.VerifyBlockSeal(&block.Header, validatorState.SafroleState.SealingKeySeries, validatorState.CurrentValidators, output.SealingEntropy)
+	if err != nil {
+		return fmt.Errorf("failed to verify block seal: %w", err)
+	}
+	if !ok {
+		return errors.New("block seal or vrf signature is invalid")
+	}
+
+	return nil
+}

--- a/internal/statetransition/safrole.go
+++ b/internal/statetransition/safrole.go
@@ -1,0 +1,342 @@
+package statetransition
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"errors"
+	"sort"
+
+	"github.com/eigerco/strawberry/internal/block"
+	"github.com/eigerco/strawberry/internal/common"
+	"github.com/eigerco/strawberry/internal/crypto"
+	"github.com/eigerco/strawberry/internal/crypto/bandersnatch"
+	"github.com/eigerco/strawberry/internal/jamtime"
+	"github.com/eigerco/strawberry/internal/safrole"
+	"github.com/eigerco/strawberry/internal/state"
+	"github.com/eigerco/strawberry/internal/validator"
+)
+
+// Input to UpdateSafroleState. Derived from the incoming block.
+type SafroleInput struct {
+	// Next timeslot.
+	TimeSlot jamtime.Timeslot
+	// Ticket extrinsic (E_T).
+	Tickets []block.TicketProof
+	// Y(Hv)
+	Entropy crypto.BandersnatchOutputHash
+}
+
+func NewSafroleInputFromBlock(block block.Block) (SafroleInput, error) {
+	entropy, err := bandersnatch.OutputHash(block.Header.VRFSignature)
+	if err != nil {
+		return SafroleInput{}, err
+	}
+
+	// TODO - might want to make a deep copy for ticket proofs and offenders
+	// here, but should be ok since it's read only.
+	return SafroleInput{
+		TimeSlot: block.Header.TimeSlotIndex,
+		Tickets:  block.Extrinsic.ET.TicketProofs,
+		Entropy:  entropy,
+	}, nil
+}
+
+// Output from UpdateSafroleState.
+type SafroleOutput struct {
+	// H_e
+	EpochMark *block.EpochMarker
+	// H_w
+	WinningTicketMark *block.WinningTicketMarker
+
+	// Entropies for use by downstream functions that might also use this output.
+	TicketEntropy  crypto.Hash // n_2
+	SealingEntropy crypto.Hash // n_3
+}
+
+// Validates then produces tickets from submitted ticket proofs.
+// Implements equations 74-80 in the graypaper (v.0.4.5)
+// ET ∈ D{r ∈ NN, p ∈ F̄[]γz⟨XT ⌢ η′2 r⟩}I  (74)
+// |ET| ≤ K if m′ < Y                        (75)
+// n ≡ [{y ▸ Y(ip), r ▸ ir} S i <− ET]      (76)
+// n = [xy __ x ∈ n]                         (77)
+// {xy S x ∈ n} ⫰ {xy S x ∈ γa}             (78)
+// γ′a ≡ [xy^^ x ∈ n ∪ {∅ if e′ > e, γa otherwise}]E  (79)
+func calculateTickets(safstate safrole.State, entropyPool state.EntropyPool, ticketProofs []block.TicketProof) ([]block.Ticket, error) {
+	// Equation 75: |ET| ≤ K if m′ < Y (v.0.4.5)
+	if len(ticketProofs) > common.MaxTicketExtrinsicSize {
+		return []block.Ticket{}, errors.New("too many tickets")
+	}
+
+	ringVerifier, err := safstate.NextValidators.RingVerifier()
+	defer ringVerifier.Free()
+	if err != nil {
+		return []block.Ticket{}, err
+	}
+
+	// Equation 78: {xy S x ∈ n} ⫰ {xy S x ∈ γa} (v.0.4.5)
+	// Check for duplicate tickets in γ_a
+	existingIds := make(map[crypto.BandersnatchOutputHash]struct{}, len(safstate.TicketAccumulator))
+	for _, ticket := range safstate.TicketAccumulator {
+		existingIds[ticket.Identifier] = struct{}{}
+	}
+	// Equations 74 and 76 (v.0.4.5)
+	// ET ∈ D{r ∈ NN, p ∈ F̄[]γz⟨XT ⌢ η′2 r⟩}I
+	// n ≡ [{y ▸ Y(ip), r ▸ ir} S i <− ET]
+	tickets := make([]block.Ticket, len(ticketProofs))
+	for i, tp := range ticketProofs {
+		// Equation 6.29: r ∈ N_N (v.0.5.4)
+		if tp.EntryIndex >= common.MaxTicketAttempts {
+			return []block.Ticket{}, errors.New("bad ticket attempt")
+		}
+
+		// Validate the ring signature. VrfInputData is X_t ⌢ η_2′ ++ r. Equation 74. (v.0.4.5)
+		vrfInputData := append([]byte(state.TicketSealContext), entropyPool[2][:]...)
+		vrfInputData = append(vrfInputData, tp.EntryIndex)
+		// This produces the output hash we need to construct the ticket further down.
+		ok, outputHash := ringVerifier.Verify(vrfInputData, []byte{}, safstate.RingCommitment, tp.Proof)
+		if !ok {
+			return []block.Ticket{}, errors.New("bad ticket proof")
+		}
+
+		// Equation 78: {xy S x ∈ n} ⫰ {xy S x ∈ γa} (v.0.4.5)
+		if _, exists := existingIds[outputHash]; exists {
+			return []block.Ticket{}, errors.New("duplicate ticket")
+		}
+
+		// Equation 76: n ≡ [{y ▸ Y(ip), r ▸ ir} S i <− ET] (v.0.4.5)
+		tickets[i] = block.Ticket{
+			Identifier: outputHash,
+			EntryIndex: tp.EntryIndex,
+		}
+	}
+
+	// Equation 77: n = [xy __ x ∈ n] (v.0.4.5)
+	// Verify tickets are ordered by identifier
+	for i := 1; i < len(tickets); i++ {
+		prevHash := tickets[i-1].Identifier
+		currentHash := tickets[i].Identifier
+		if bytes.Compare(prevHash[:], currentHash[:]) >= 0 {
+			return []block.Ticket{}, errors.New("bad ticket order")
+		}
+	}
+
+	return tickets, nil
+}
+
+// Implements section 6 of the graypaper.
+// Updates all state associated with the SAFROLE protocol.
+// Implements key equations (v.0.4.5)
+// γ′k ≡ Φ(ι) if e′ > e                     (58)
+// γ′s ≡ Z(γa) if e′ = e + 1 ∧ m ≥ Y ∧ |γa| = E
+//
+//	γs if e′ = e
+//	F(η′2, κ′) otherwise                (69)
+//
+// He ≡ (η′1, [kb S k <− γ′k]) if e′ > e
+//
+//	∅ otherwise                          (72)
+//
+// Hw ≡ Z(γa) if e′ = e ∧ m < Y ≤ m′ ∧ |γa| = E
+//
+//	∅ otherwise                          (73)
+func UpdateSafroleState(
+	input SafroleInput,
+	preTimeSlot jamtime.Timeslot,
+	entropyPool state.EntropyPool,
+	validatorState validator.ValidatorState,
+	offenders []ed25519.PublicKey,
+) (state.EntropyPool, validator.ValidatorState, SafroleOutput, error) {
+	if input.TimeSlot <= preTimeSlot {
+		return entropyPool, validatorState, SafroleOutput{}, errors.New("bad slot")
+	}
+
+	nextTimeSlot := input.TimeSlot
+
+	// Equations 67, 68 (v.0.4.5)
+	// η′0 ≡ H(η0 ⌢ Y(Hv))
+	// (η′1, η′2, η′3) ≡ (η0, η1, η2) if e′ > e
+	newEntropyPool, err := calculateNewEntropyPool(preTimeSlot, nextTimeSlot, input.Entropy, entropyPool)
+	if err != nil {
+		return entropyPool, validatorState, SafroleOutput{}, err
+	}
+
+	newValidatorState := validatorState
+	output := SafroleOutput{
+		TicketEntropy:  newEntropyPool[2],
+		SealingEntropy: newEntropyPool[3],
+	}
+
+	epoch := nextTimeSlot.ToEpoch()   // e'
+	preEpoch := preTimeSlot.ToEpoch() // e
+	// |γ_a| = E, a condition of equation 73.
+	ticketAccumulatorFull := len(validatorState.SafroleState.TicketAccumulator) == jamtime.TimeslotsPerEpoch
+
+	// Note that this condition allows epochs to be skipped, e' > e, as in equations 58, 68, 72. (v.0.4.5)
+	// We don't care about the timeslot, only the epoch.
+	// Equation 58: (γ′k, κ′, λ′, γ′z) ≡ (Φ(ι), γk, κ, z) if e′ > e
+	if epoch > preEpoch {
+		// Equation 59: Φ(k) ≡ [0, 0, ...] if ke ∈ ψ′o (v.0.4.5)
+		//                     k otherwise
+		newValidatorState.SafroleState.NextValidators = validator.NullifyOffenders(validatorState.QueuedValidators, offenders)
+		newValidatorState.CurrentValidators = validatorState.SafroleState.NextValidators
+		newValidatorState.ArchivedValidators = validatorState.CurrentValidators
+
+		// Calculate new ring commitment. (γ_z) . Apply the O function from equation 58.
+		//  Equation 58: z = O([kb S k <− γ′k])
+		ringCommitment, err := newValidatorState.SafroleState.NextValidators.RingCommitment()
+		if err != nil {
+			return entropyPool, validatorState, SafroleOutput{}, errors.New("unable to calculate ring commitment")
+		}
+		newValidatorState.SafroleState.RingCommitment = ringCommitment
+
+		// Determine the sealing keys.  Standard way is to use
+		// tickets as sealing keys, if we can't then fall back to selecting
+		// bandersnatch validator keys for sealing randomly using past entropy.
+		// Equation 69: γ′s ≡ Z(γa) if e′ = e + 1 ∧ m ≥ Y ∧ |γa| = E (v.0.4.5)
+		//                    γs if e′ = e
+		//                    F(η′2, κ′) otherwise
+		if epoch == preEpoch+jamtime.Epoch(1) &&
+			// m >= Y
+			!preTimeSlot.IsTicketSubmissionPeriod() &&
+			// |γ_a| = E
+			ticketAccumulatorFull {
+			// Use tickets for sealing keys. Apply the Z function on the ticket accumulator.
+			sealingTickets := safrole.OutsideInSequence(newValidatorState.SafroleState.TicketAccumulator)
+			newValidatorState.SafroleState.SealingKeySeries.Set(safrole.TicketsBodies(sealingTickets))
+		} else {
+			// Use bandersnatch keys for sealing keys.
+			fallbackKeys, err := safrole.SelectFallbackKeys(newEntropyPool[2], newValidatorState.CurrentValidators)
+			if err != nil {
+				return entropyPool, validatorState, SafroleOutput{}, err
+			}
+			newValidatorState.SafroleState.SealingKeySeries.Set(fallbackKeys)
+		}
+
+		// Compute epoch marker (H_e).
+		// Equation 6.27: He ≡ (η0, n1, [kb S k <− γ′k]) if e′ > e (v.0.5.4)
+		output.EpochMark = &block.EpochMarker{
+			Entropy:        entropyPool[0],
+			TicketsEntropy: entropyPool[1],
+		}
+		for i, vd := range newValidatorState.SafroleState.NextValidators {
+			output.EpochMark.Keys[i] = block.ValidatorKeys{
+				Bandersnatch: vd.Bandersnatch,
+				Ed25519:      vd.Ed25519,
+			}
+		}
+
+		// Reset ticket accumulator. From equation 79.
+		newValidatorState.SafroleState.TicketAccumulator = []block.Ticket{}
+	}
+
+	// Check if we need to generate the winning tickets marker.
+	// // Equation 73: Hw ≡ Z(γa) if e′ = e ∧ m < Y ≤ m′ ∧ |γa| = E (v.0.4.5)
+	if epoch == preEpoch &&
+		nextTimeSlot.IsWinningTicketMarkerPeriod(preTimeSlot) &&
+		ticketAccumulatorFull {
+		// Apply the Z function to the ticket accumulator.
+		winningTickets := safrole.OutsideInSequence(newValidatorState.SafroleState.TicketAccumulator)
+		output.WinningTicketMark = (*block.WinningTicketMarker)(winningTickets)
+	}
+
+	// Process incoming tickets.  Check if we're still allowed to submit
+	// tickets. An implication of equation 75. m' < Y to submit.
+	if !nextTimeSlot.IsTicketSubmissionPeriod() && len(input.Tickets) > 0 {
+		return entropyPool, validatorState, SafroleOutput{}, errors.New("unexpected ticket")
+	}
+
+	if len(input.Tickets) > 0 {
+		// Validate ticket proofs and produce tickets. Tickets produced are n.
+		// As in equation 76.
+		tickets, err := calculateTickets(newValidatorState.SafroleState, newEntropyPool, input.Tickets)
+		if err != nil {
+			return entropyPool, validatorState, SafroleOutput{}, err
+		}
+
+		// Update the accumulator γ_a.
+		// Equation 79: γ′a ≡ [xy^^ x ∈ n ∪ {∅ if e′ > e, γa otherwise}]E (v.0.4.5)
+		// Combine existing and new tickets.
+		accumulator := newValidatorState.SafroleState.TicketAccumulator
+		allTickets := make([]block.Ticket, len(accumulator)+len(tickets))
+		copy(allTickets, accumulator)
+		copy(allTickets[len(accumulator):], tickets)
+
+		// Resort by identifier.
+		sort.Slice(allTickets, func(i, j int) bool {
+			return bytes.Compare(allTickets[i].Identifier[:], allTickets[j].Identifier[:]) < 0
+		})
+
+		// Drop older tickets, limiting the accumulator to |E|.
+		if len(allTickets) > jamtime.TimeslotsPerEpoch {
+			allTickets = allTickets[:jamtime.TimeslotsPerEpoch]
+		}
+
+		// Ensure all incoming tickets exist in the accumulator. No useless
+		// tickets are allowed. Equation 6.35: n ⊆ γ′a (v.0.5.4)
+		existingIds := make(map[crypto.BandersnatchOutputHash]struct{}, len(allTickets))
+		for _, ticket := range allTickets {
+			existingIds[ticket.Identifier] = struct{}{}
+		}
+		for _, ticket := range tickets {
+			if _, ok := existingIds[ticket.Identifier]; !ok {
+				return entropyPool, validatorState, SafroleOutput{}, errors.New("useless ticket")
+			}
+		}
+		newValidatorState.SafroleState.TicketAccumulator = allTickets
+	}
+
+	return newEntropyPool, newValidatorState, output, nil
+}
+
+// Implements equations 67 and 68 from the graypaper. (v.0.4.5)
+// The entropyInput is assumed to be bandersnatch output hash from the block vrf siganture, Y(Hv).
+// The entryPool is defined as equation 66.
+// Calculates η′0 ≡ H(η0 ⌢ Y(Hv)) every slot, and rotates the entropies on epoch change.
+func calculateNewEntropyPool(currentTimeslot jamtime.Timeslot, newTimeslot jamtime.Timeslot, entropyInput crypto.BandersnatchOutputHash, entropyPool state.EntropyPool) (state.EntropyPool, error) {
+	newEntropyPool := entropyPool
+
+	if newTimeslot.ToEpoch() > currentTimeslot.ToEpoch() {
+		newEntropyPool = rotateEntropyPool(entropyPool)
+	}
+
+	newEntropyPool[0] = crypto.HashData(append(entropyPool[0][:], entropyInput[:]...))
+	return newEntropyPool, nil
+}
+
+func rotateEntropyPool(pool state.EntropyPool) state.EntropyPool {
+	pool[3] = pool[2]
+	pool[2] = pool[1]
+	pool[1] = pool[0]
+	return pool
+}
+
+// Determines the next SAFROLE state. Useful for functions that need to
+// determine the SAFROLE state outside of the main UpdateState function. It
+// makes dealing with all the edge cases on epoch change much easier. Returns
+// the next ValidatorState together with the SAFROLE output which includes the
+// entropy entries to use for ticket submission and block sealing. Disputes only
+// need to be included in specific cases where an updated pending validator set
+// (γ_k) is required for some calculation.
+func NextSafroleState(priorState *state.State, nextTimeslot jamtime.Timeslot, disputes block.DisputeExtrinsic) (
+	validator.ValidatorState,
+	SafroleOutput,
+	error) {
+	newJudgements, err := CalculateNewJudgements(priorState.TimeslotIndex, disputes, priorState.PastJudgements, priorState.ValidatorState)
+	if err != nil {
+		return validator.ValidatorState{}, SafroleOutput{}, err
+	}
+	input := SafroleInput{
+		TimeSlot: nextTimeslot,
+		// Empty because at this point we don't yet have Y(Hv) nor do we ever
+		// need it for anything that might use this function. We only ever care
+		// about the entropy pool's 1st to 3rd indexes.
+		Entropy: crypto.BandersnatchOutputHash{},
+	}
+
+	_, validatorState, output, err := UpdateSafroleState(input, priorState.TimeslotIndex, priorState.EntropyPool, priorState.ValidatorState, newJudgements.OffendingValidators)
+	if err != nil {
+		return validator.ValidatorState{}, SafroleOutput{}, err
+	}
+
+	return validatorState, output, nil
+}

--- a/internal/statetransition/state_transition.go
+++ b/internal/statetransition/state_transition.go
@@ -16,7 +16,6 @@ import (
 	"github.com/eigerco/strawberry/internal/block"
 	"github.com/eigerco/strawberry/internal/common"
 	"github.com/eigerco/strawberry/internal/crypto"
-	"github.com/eigerco/strawberry/internal/crypto/bandersnatch"
 	"github.com/eigerco/strawberry/internal/disputes"
 	"github.com/eigerco/strawberry/internal/jamtime"
 	"github.com/eigerco/strawberry/internal/merkle/binary_tree"
@@ -35,9 +34,10 @@ import (
 // TODO: all the calculations which are not dependent on intermediate / new state can be done in parallel
 //
 //	it might be worth making State immutable and make it so that UpdateState returns a new State with all the updated fields
-func UpdateState(s *state.State, newBlock block.Block, chain *store.Chain) error {
-	if newBlock.Header.TimeSlotIndex.IsInFuture() {
-		return errors.New("invalid block, it is in the future")
+func UpdateState(s *state.State, newBlock block.Block, chain *store.Chain, trie *store.Trie) error {
+	err := VerifyBlockHeaderBasic(s, newBlock, trie)
+	if err != nil {
+		return fmt.Errorf("failed to verify block header: %w", err)
 	}
 
 	prevTimeSlot := s.TimeslotIndex
@@ -58,12 +58,14 @@ func UpdateState(s *state.State, newBlock block.Block, chain *store.Chain) error
 		return err
 	}
 
+	// TODO: verify header offenders marker.
+
 	// Update SAFROLE state.
 	safroleInput, err := NewSafroleInputFromBlock(newBlock)
 	if err != nil {
 		return err
 	}
-	newEntropyPool, newValidatorState, _, err := UpdateSafroleState(
+	newEntropyPool, newValidatorState, safroleOutput, err := UpdateSafroleState(
 		safroleInput,
 		prevTimeSlot,
 		s.EntropyPool,
@@ -71,6 +73,11 @@ func UpdateState(s *state.State, newBlock block.Block, chain *store.Chain) error
 		newJudgements.OffendingValidators)
 	if err != nil {
 		return err
+	}
+
+	err = VerifyBlockHeaderSafrole(newValidatorState, safroleOutput, newBlock)
+	if err != nil {
+		return fmt.Errorf("failed to verify block header: %w", err)
 	}
 
 	intermediateCoreAssignments, _, err = CalculateIntermediateCoreFromAssurances(s.ValidatorState.CurrentValidators, intermediateCoreAssignments, newBlock.Header, newBlock.Extrinsic.EA)
@@ -492,300 +499,6 @@ func buildWorkPackageMapping(guarantees []block.Guarantee) map[crypto.Hash]crypt
 			g.WorkReport.WorkPackageSpecification.SegmentRoot
 	}
 	return workPackages
-}
-
-// Input to UpdateSafroleState. Derived from the incoming block.
-type SafroleInput struct {
-	// Next timeslot.
-	TimeSlot jamtime.Timeslot
-	// Ticket extrinsic (E_T).
-	Tickets []block.TicketProof
-	// Y(Hv)
-	Entropy crypto.BandersnatchOutputHash
-}
-
-func NewSafroleInputFromBlock(block block.Block) (SafroleInput, error) {
-	entropy, err := bandersnatch.OutputHash(block.Header.VRFSignature)
-	if err != nil {
-		return SafroleInput{}, err
-	}
-
-	// TODO - might want to make a deep copy for ticket proofs and offenders
-	// here, but should be ok since it's read only.
-	return SafroleInput{
-		TimeSlot: block.Header.TimeSlotIndex,
-		Tickets:  block.Extrinsic.ET.TicketProofs,
-		Entropy:  entropy,
-	}, nil
-}
-
-// Output from UpdateSafroleState.
-type SafroleOutput struct {
-	// H_e
-	EpochMark *block.EpochMarker
-	// H_w
-	WinningTicketMark *block.WinningTicketMarker
-
-	// Entropies for use by downstream functions that might also use this output.
-	TicketEntropy  crypto.Hash // n_2
-	SealingEntropy crypto.Hash // n_3
-}
-
-// Validates then produces tickets from submitted ticket proofs.
-// Implements equations 74-80 in the graypaper (v.0.4.5)
-// ET ∈ D{r ∈ NN, p ∈ F̄[]γz⟨XT ⌢ η′2 r⟩}I  (74)
-// |ET| ≤ K if m′ < Y                        (75)
-// n ≡ [{y ▸ Y(ip), r ▸ ir} S i <− ET]      (76)
-// n = [xy __ x ∈ n]                         (77)
-// {xy S x ∈ n} ⫰ {xy S x ∈ γa}             (78)
-// γ′a ≡ [xy^^ x ∈ n ∪ {∅ if e′ > e, γa otherwise}]E  (79)
-func calculateTickets(safstate safrole.State, entropyPool state.EntropyPool, ticketProofs []block.TicketProof) ([]block.Ticket, error) {
-	// Equation 75: |ET| ≤ K if m′ < Y (v.0.4.5)
-	if len(ticketProofs) > common.MaxTicketExtrinsicSize {
-		return []block.Ticket{}, errors.New("too many tickets")
-	}
-
-	ringVerifier, err := safstate.NextValidators.RingVerifier()
-	defer ringVerifier.Free()
-	if err != nil {
-		return []block.Ticket{}, err
-	}
-
-	// Equation 78: {xy S x ∈ n} ⫰ {xy S x ∈ γa} (v.0.4.5)
-	// Check for duplicate tickets in γ_a
-	existingIds := make(map[crypto.BandersnatchOutputHash]struct{}, len(safstate.TicketAccumulator))
-	for _, ticket := range safstate.TicketAccumulator {
-		existingIds[ticket.Identifier] = struct{}{}
-	}
-	// Equations 74 and 76 (v.0.4.5)
-	// ET ∈ D{r ∈ NN, p ∈ F̄[]γz⟨XT ⌢ η′2 r⟩}I
-	// n ≡ [{y ▸ Y(ip), r ▸ ir} S i <− ET]
-	tickets := make([]block.Ticket, len(ticketProofs))
-	for i, tp := range ticketProofs {
-		// Equation 6.29: r ∈ N_N (v.0.5.4)
-		if tp.EntryIndex >= common.MaxTicketAttempts {
-			return []block.Ticket{}, errors.New("bad ticket attempt")
-		}
-
-		// Validate the ring signature. VrfInputData is X_t ⌢ η_2′ ++ r. Equation 74. (v.0.4.5)
-		vrfInputData := append([]byte(state.TicketSealContext), entropyPool[2][:]...)
-		vrfInputData = append(vrfInputData, tp.EntryIndex)
-		// This produces the output hash we need to construct the ticket further down.
-		ok, outputHash := ringVerifier.Verify(vrfInputData, []byte{}, safstate.RingCommitment, tp.Proof)
-		if !ok {
-			return []block.Ticket{}, errors.New("bad ticket proof")
-		}
-
-		// Equation 78: {xy S x ∈ n} ⫰ {xy S x ∈ γa} (v.0.4.5)
-		if _, exists := existingIds[outputHash]; exists {
-			return []block.Ticket{}, errors.New("duplicate ticket")
-		}
-
-		// Equation 76: n ≡ [{y ▸ Y(ip), r ▸ ir} S i <− ET] (v.0.4.5)
-		tickets[i] = block.Ticket{
-			Identifier: outputHash,
-			EntryIndex: tp.EntryIndex,
-		}
-	}
-
-	// Equation 77: n = [xy __ x ∈ n] (v.0.4.5)
-	// Verify tickets are ordered by identifier
-	for i := 1; i < len(tickets); i++ {
-		prevHash := tickets[i-1].Identifier
-		currentHash := tickets[i].Identifier
-		if bytes.Compare(prevHash[:], currentHash[:]) >= 0 {
-			return []block.Ticket{}, errors.New("bad ticket order")
-		}
-	}
-
-	return tickets, nil
-}
-
-// Implements section 6 of the graypaper.
-// Updates all state associated with the SAFROLE protocol.
-// Implements key equations (v.0.4.5)
-// γ′k ≡ Φ(ι) if e′ > e                     (58)
-// γ′s ≡ Z(γa) if e′ = e + 1 ∧ m ≥ Y ∧ |γa| = E
-//
-//	γs if e′ = e
-//	F(η′2, κ′) otherwise                (69)
-//
-// He ≡ (η′1, [kb S k <− γ′k]) if e′ > e
-//
-//	∅ otherwise                          (72)
-//
-// Hw ≡ Z(γa) if e′ = e ∧ m < Y ≤ m′ ∧ |γa| = E
-//
-//	∅ otherwise                          (73)
-func UpdateSafroleState(
-	input SafroleInput,
-	preTimeSlot jamtime.Timeslot,
-	entropyPool state.EntropyPool,
-	validatorState validator.ValidatorState,
-	offenders []ed25519.PublicKey,
-) (state.EntropyPool, validator.ValidatorState, SafroleOutput, error) {
-	if input.TimeSlot <= preTimeSlot {
-		return entropyPool, validatorState, SafroleOutput{}, errors.New("bad slot")
-	}
-
-	nextTimeSlot := input.TimeSlot
-
-	// Equations 67, 68 (v.0.4.5)
-	// η′0 ≡ H(η0 ⌢ Y(Hv))
-	// (η′1, η′2, η′3) ≡ (η0, η1, η2) if e′ > e
-	newEntropyPool, err := calculateNewEntropyPool(preTimeSlot, nextTimeSlot, input.Entropy, entropyPool)
-	if err != nil {
-		return entropyPool, validatorState, SafroleOutput{}, err
-	}
-
-	newValidatorState := validatorState
-	output := SafroleOutput{
-		TicketEntropy:  newEntropyPool[2],
-		SealingEntropy: newEntropyPool[3],
-	}
-
-	epoch := nextTimeSlot.ToEpoch()   // e'
-	preEpoch := preTimeSlot.ToEpoch() // e
-	// |γ_a| = E, a condition of equation 73.
-	ticketAccumulatorFull := len(validatorState.SafroleState.TicketAccumulator) == jamtime.TimeslotsPerEpoch
-
-	// Note that this condition allows epochs to be skipped, e' > e, as in equations 58, 68, 72. (v.0.4.5)
-	// We don't care about the timeslot, only the epoch.
-	// Equation 58: (γ′k, κ′, λ′, γ′z) ≡ (Φ(ι), γk, κ, z) if e′ > e
-	if epoch > preEpoch {
-		// Equation 59: Φ(k) ≡ [0, 0, ...] if ke ∈ ψ′o (v.0.4.5)
-		//                     k otherwise
-		newValidatorState.SafroleState.NextValidators = validator.NullifyOffenders(validatorState.QueuedValidators, offenders)
-		newValidatorState.CurrentValidators = validatorState.SafroleState.NextValidators
-		newValidatorState.ArchivedValidators = validatorState.CurrentValidators
-
-		// Calculate new ring commitment. (γ_z) . Apply the O function from equation 58.
-		//  Equation 58: z = O([kb S k <− γ′k])
-		ringCommitment, err := newValidatorState.SafroleState.NextValidators.RingCommitment()
-		if err != nil {
-			return entropyPool, validatorState, SafroleOutput{}, errors.New("unable to calculate ring commitment")
-		}
-		newValidatorState.SafroleState.RingCommitment = ringCommitment
-
-		// Determine the sealing keys.  Standard way is to use
-		// tickets as sealing keys, if we can't then fall back to selecting
-		// bandersnatch validator keys for sealing randomly using past entropy.
-		// Equation 69: γ′s ≡ Z(γa) if e′ = e + 1 ∧ m ≥ Y ∧ |γa| = E (v.0.4.5)
-		//                    γs if e′ = e
-		//                    F(η′2, κ′) otherwise
-		if epoch == preEpoch+jamtime.Epoch(1) &&
-			// m >= Y
-			!preTimeSlot.IsTicketSubmissionPeriod() &&
-			// |γ_a| = E
-			ticketAccumulatorFull {
-			// Use tickets for sealing keys. Apply the Z function on the ticket accumulator.
-			sealingTickets := safrole.OutsideInSequence(newValidatorState.SafroleState.TicketAccumulator)
-			newValidatorState.SafroleState.SealingKeySeries.Set(safrole.TicketsBodies(sealingTickets))
-		} else {
-			// Use bandersnatch keys for sealing keys.
-			fallbackKeys, err := safrole.SelectFallbackKeys(newEntropyPool[2], newValidatorState.CurrentValidators)
-			if err != nil {
-				return entropyPool, validatorState, SafroleOutput{}, err
-			}
-			newValidatorState.SafroleState.SealingKeySeries.Set(fallbackKeys)
-		}
-
-		// Compute epoch marker (H_e).
-		// Equation 6.27: He ≡ (η0, n1, [kb S k <− γ′k]) if e′ > e (v.0.5.4)
-		output.EpochMark = &block.EpochMarker{
-			Entropy:        entropyPool[0],
-			TicketsEntropy: entropyPool[1],
-		}
-		for i, vd := range newValidatorState.SafroleState.NextValidators {
-			output.EpochMark.Keys[i] = block.ValidatorKeys{
-				Bandersnatch: vd.Bandersnatch,
-				Ed25519:      vd.Ed25519,
-			}
-		}
-
-		// Reset ticket accumulator. From equation 79.
-		newValidatorState.SafroleState.TicketAccumulator = []block.Ticket{}
-	}
-
-	// Check if we need to generate the winning tickets marker.
-	// // Equation 73: Hw ≡ Z(γa) if e′ = e ∧ m < Y ≤ m′ ∧ |γa| = E (v.0.4.5)
-	if epoch == preEpoch &&
-		nextTimeSlot.IsWinningTicketMarkerPeriod(preTimeSlot) &&
-		ticketAccumulatorFull {
-		// Apply the Z function to the ticket accumulator.
-		winningTickets := safrole.OutsideInSequence(newValidatorState.SafroleState.TicketAccumulator)
-		output.WinningTicketMark = (*block.WinningTicketMarker)(winningTickets)
-	}
-
-	// Process incoming tickets.  Check if we're still allowed to submit
-	// tickets. An implication of equation 75. m' < Y to submit.
-	if !nextTimeSlot.IsTicketSubmissionPeriod() && len(input.Tickets) > 0 {
-		return entropyPool, validatorState, SafroleOutput{}, errors.New("unexpected ticket")
-	}
-
-	if len(input.Tickets) > 0 {
-		// Validate ticket proofs and produce tickets. Tickets produced are n.
-		// As in equation 76.
-		tickets, err := calculateTickets(newValidatorState.SafroleState, newEntropyPool, input.Tickets)
-		if err != nil {
-			return entropyPool, validatorState, SafroleOutput{}, err
-		}
-
-		// Update the accumulator γ_a.
-		// Equation 79: γ′a ≡ [xy^^ x ∈ n ∪ {∅ if e′ > e, γa otherwise}]E (v.0.4.5)
-		// Combine existing and new tickets.
-		accumulator := newValidatorState.SafroleState.TicketAccumulator
-		allTickets := make([]block.Ticket, len(accumulator)+len(tickets))
-		copy(allTickets, accumulator)
-		copy(allTickets[len(accumulator):], tickets)
-
-		// Resort by identifier.
-		sort.Slice(allTickets, func(i, j int) bool {
-			return bytes.Compare(allTickets[i].Identifier[:], allTickets[j].Identifier[:]) < 0
-		})
-
-		// Drop older tickets, limiting the accumulator to |E|.
-		if len(allTickets) > jamtime.TimeslotsPerEpoch {
-			allTickets = allTickets[:jamtime.TimeslotsPerEpoch]
-		}
-
-		// Ensure all incoming tickets exist in the accumulator. No useless
-		// tickets are allowed. Equation 6.35: n ⊆ γ′a (v.0.5.4)
-		existingIds := make(map[crypto.BandersnatchOutputHash]struct{}, len(allTickets))
-		for _, ticket := range allTickets {
-			existingIds[ticket.Identifier] = struct{}{}
-		}
-		for _, ticket := range tickets {
-			if _, ok := existingIds[ticket.Identifier]; !ok {
-				return entropyPool, validatorState, SafroleOutput{}, errors.New("useless ticket")
-			}
-		}
-		newValidatorState.SafroleState.TicketAccumulator = allTickets
-	}
-
-	return newEntropyPool, newValidatorState, output, nil
-}
-
-// Implements equations 67 and 68 from the graypaper. (v.0.4.5)
-// The entropyInput is assumed to be bandersnatch output hash from the block vrf siganture, Y(Hv).
-// The entryPool is defined as equation 66.
-// Calculates η′0 ≡ H(η0 ⌢ Y(Hv)) every slot, and rotates the entropies on epoch change.
-func calculateNewEntropyPool(currentTimeslot jamtime.Timeslot, newTimeslot jamtime.Timeslot, entropyInput crypto.BandersnatchOutputHash, entropyPool state.EntropyPool) (state.EntropyPool, error) {
-	newEntropyPool := entropyPool
-
-	if newTimeslot.ToEpoch() > currentTimeslot.ToEpoch() {
-		newEntropyPool = rotateEntropyPool(entropyPool)
-	}
-
-	newEntropyPool[0] = crypto.HashData(append(entropyPool[0][:], entropyInput[:]...))
-	return newEntropyPool, nil
-}
-
-func rotateEntropyPool(pool state.EntropyPool) state.EntropyPool {
-	pool[3] = pool[2]
-	pool[2] = pool[1]
-	pool[1] = pool[0]
-	return pool
 }
 
 // CalculateNewCoreAuthorizations implements equation 4.19: α' ≺ (H, EG, φ', α) . Graypaper 0.5.4

--- a/tests/simulation/assurance_block_001.json
+++ b/tests/simulation/assurance_block_001.json
@@ -1,14 +1,15 @@
 {
     "header": {
         "parent": "0x476243ad7cc4fc49cb6cb362c6568e931731d8650d917007a6037cceedd62244",
-        "parent_state_root": "0xdc7695047ae21f0e8dd14b94c8a96ed82c7fcefaf064da03876e804673a6ddb2",
-        "extrinsic_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "parent_state_root": "0xbacc4267121e6958ad3d23f16ab7cabecf306723866b7132289400c6377c4473",
+        "extrinsic_hash": "0x2586eecb3a83d9977be3a113978ab58908ecaf55f42ac46b4f3c8abda2bac636",
         "slot": 1,
+        "epoch_mark": null,
         "tickets_mark": null,
         "offenders_mark": [],
-        "author_index": 1,
+        "author_index": 0,
         "entropy_source": "0x471e9a13ad977962ae5c68898274c0ef255ec80c9d31b26c80c2e18cf76fbc2e3dc9de282931e780db3a282fcc7abf34056404db728c64d8073c8074bc8cb51a7b6bfc64c8f902ad8e85f83a3c85bc1b2757fb3dd7ebab33c00a065823ffdc17",
-        "seal": "0xabc77c8ba19cee69325f04258b882d6515ee600e4f5da8b44b17985e096a3b29154732fa5359bad6939a4584169d39c58d59a5c017064ea74a2ec435685a8107cc5d10e5c8aba63400e4d224d221b9d36a430258d2a70b1b73bed538200e7f03"
+        "seal": "0xabc77c8ba19cee69325f04258b882d6515ee600e4f5da8b44b17985e096a3b298af314d0ffbe5d04bec6b73bd534c3ee2ed96acb117cae1c51ce123433125002e44cf4f3f6734873c2219885f17e424212860ed2f61ed4fd32d61993e8b8b010"
     },
     "extrinsic": {
         "tickets": [],

--- a/tests/simulation/disputes_block_001.json
+++ b/tests/simulation/disputes_block_001.json
@@ -1,7 +1,7 @@
 {
     "header": {
         "parent": "0x476243ad7cc4fc49cb6cb362c6568e931731d8650d917007a6037cceedd62244",
-        "parent_state_root": "0xc3a8849fb14674e1e0bfacf2a3cd094bcbac688330745b5b1e5a5cba88997137",
+        "parent_state_root": "0xa00b983eb2c07ef6bd4ea92f29dad2ce1903a0e960ed279d4005cd95316cce83",
         "extrinsic_hash": "0x72190a42070f29a487a554213f258b569aea109758e26347577488fd1a8d6749",
         "slot": 1,
         "epoch_mark": null,
@@ -12,7 +12,7 @@
         ],
         "author_index": 0,
         "entropy_source": "0x471e9a13ad977962ae5c68898274c0ef255ec80c9d31b26c80c2e18cf76fbc2e3dc9de282931e780db3a282fcc7abf34056404db728c64d8073c8074bc8cb51a7b6bfc64c8f902ad8e85f83a3c85bc1b2757fb3dd7ebab33c00a065823ffdc17",
-        "seal": "0xabc77c8ba19cee69325f04258b882d6515ee600e4f5da8b44b17985e096a3b290e1e5a9b9d779dcdfbb81801f9d8bb47598263d4d3b51e03ee6d3b05c0b9cc0e772b2782ddfc91f588a7d3332da98e58311e05eef582ef25dcc4f34a2629cd18"
+        "seal": "0xabc77c8ba19cee69325f04258b882d6515ee600e4f5da8b44b17985e096a3b29658902dac0402b7bdeabc42f4fce5daef261353fda2fc9cdfe3daba6ff7f5617c38ebb6a1edde20fffcc3d4f47b63d803ed6001a520e2692c6634368d7806b1a"
     },
     "extrinsic": {
         "tickets": [],

--- a/tests/simulation/guarantee_block_001.json
+++ b/tests/simulation/guarantee_block_001.json
@@ -1,14 +1,15 @@
 {
     "header": {
         "parent": "0x476243ad7cc4fc49cb6cb362c6568e931731d8650d917007a6037cceedd62244",
-        "parent_state_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "extrinsic_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "parent_state_root": "0x5b0937c35709936c9570ad26ba0e0832e3d1d8925dd14fbbd964178aa372d14c",
+        "extrinsic_hash": "0x8918ef4432e9b8f801450d1be106c5e826262dd692e418b5d53c67b30254bd89",
         "slot": 1,
+        "epoch_mark": null,
         "tickets_mark": null,
         "offenders_mark": [],
         "author_index": 0,
         "entropy_source": "0x471e9a13ad977962ae5c68898274c0ef255ec80c9d31b26c80c2e18cf76fbc2e3dc9de282931e780db3a282fcc7abf34056404db728c64d8073c8074bc8cb51a7b6bfc64c8f902ad8e85f83a3c85bc1b2757fb3dd7ebab33c00a065823ffdc17",
-        "seal": "0xabc77c8ba19cee69325f04258b882d6515ee600e4f5da8b44b17985e096a3b29154732fa5359bad6939a4584169d39c58d59a5c017064ea74a2ec435685a8107cc5d10e5c8aba63400e4d224d221b9d36a430258d2a70b1b73bed538200e7f03"
+        "seal": "0xabc77c8ba19cee69325f04258b882d6515ee600e4f5da8b44b17985e096a3b29858a45ca44b6e151421d3a0f01734f8d6c82a6f20406ad225f4d205f79c82113535b59ed6690dce20aed07d3068bda9af75bcf45fee4f1622526c5f02beb4114"
     },
     "extrinsic": {
         "tickets": [],
@@ -25,7 +26,7 @@
                     },
                     "context": {
                         "anchor": "0x476243ad7cc4fc49cb6cb362c6568e931731d8650d917007a6037cceedd62244",
-                        "state_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "state_root": "0x5b0937c35709936c9570ad26ba0e0832e3d1d8925dd14fbbd964178aa372d14c",
                         "beefy_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
                         "lookup_anchor": "0x60751ab5b251361fbfd3ad5b0e84f051ccece6b00830aed31a5354e00b20b9ed",
                         "lookup_anchor_slot": 33,
@@ -75,15 +76,15 @@
                 "signatures": [
                     {
                         "validator_index": 1,
-                        "signature": "0xa5d972c5603d0d999419883331957726edd9b29af8efa8c0780b6e028ba1817c17cc00ccd41108bb7907c39876d5d6d5ee249c484f070644e53de48144786200"
+                        "signature": "0x81ff9abb16df2eefa5d46820a820a747ee0b8ddcef85161780a19415caf455ffe955fc4a074149064549df8df39188273f7c630fb5c6ab658455efeb852da804"
                     },
                     {
                         "validator_index": 2,
-                        "signature": "0xbb0cd2359afb661fd6e82f8a7a6da412260068cff9530ff7a1fa5eeb6f923371ecba4635640b2c524af55faf940617b94cdc67243e2b5d0fafd69690d70bd206"
+                        "signature": "0x75719399973df76a6db425a03289eb135779a579b1d2349b6c14a74032692549aec70b7b1c1c54ead1778907ea19817d7779ad82a5079c383dcf886eb2e0d200"
                     },
                     {
                         "validator_index": 5,
-                        "signature": "0x92414235e8c029bd3bb367425eff7bb319f7f9a5727ed978a378eeccb01616d95497fcf75edae16d31827776ac4cdfece660a978678f766c572719060835d305"
+                        "signature": "0x633701bed3277ac91d691517f484e75ed38a5e9fd3b1f6ad4ea15bf49aff17bc781a8a44454cf75dc9ab1741f51921f86357701138266ab79f26a39de40f1707"
                     }
                 ]
             }

--- a/tests/simulation/preimage_block_001.json
+++ b/tests/simulation/preimage_block_001.json
@@ -1,7 +1,7 @@
 {
     "header": {
         "parent": "0x476243ad7cc4fc49cb6cb362c6568e931731d8650d917007a6037cceedd62244",
-        "parent_state_root": "0xdc7695047ae21f0e8dd14b94c8a96ed82c7fcefaf064da03876e804673a6ddb2",
+        "parent_state_root": "0x41787e62f2dc023436a018f1de429286d817f79d5c87f853191bf6bce2a04796",
         "extrinsic_hash": "0x9b567bdcf5a2c78fd328ab706f8c32f319f95e0ae28126185c6b10d2a38b3189",
         "slot": 1,
         "epoch_mark": null,
@@ -9,7 +9,7 @@
         "offenders_mark": [],
         "author_index": 0,
         "entropy_source": "0x471e9a13ad977962ae5c68898274c0ef255ec80c9d31b26c80c2e18cf76fbc2e3dc9de282931e780db3a282fcc7abf34056404db728c64d8073c8074bc8cb51a7b6bfc64c8f902ad8e85f83a3c85bc1b2757fb3dd7ebab33c00a065823ffdc17",
-        "seal": "0xabc77c8ba19cee69325f04258b882d6515ee600e4f5da8b44b17985e096a3b29154732fa5359bad6939a4584169d39c58d59a5c017064ea74a2ec435685a8107cc5d10e5c8aba63400e4d224d221b9d36a430258d2a70b1b73bed538200e7f03"
+        "seal": "0xabc77c8ba19cee69325f04258b882d6515ee600e4f5da8b44b17985e096a3b29db6ac0b709511cbc47023e64133638df1d587fd516889d23e0519bea13117a02c117d5c3ef23c5f1986deba94da6d1b832c15c9dc73454b04c84514137b9fb0a"
     },
     "extrinsic": {
         "tickets": [],

--- a/tests/simulation/simulation_assurance_test.go
+++ b/tests/simulation/simulation_assurance_test.go
@@ -57,6 +57,9 @@ func TestSimulateAssurance(t *testing.T) {
 		require.NoError(t, err, "failed to close db")
 	}()
 
+	trieDB := store.NewTrie(db)
+	require.NoError(t, err)
+
 	chainDB := store.NewChain(db)
 	require.NoError(t, err)
 
@@ -70,6 +73,7 @@ func TestSimulateAssurance(t *testing.T) {
 		currentState,
 		testBlock,
 		chainDB,
+		trieDB,
 	)
 	require.NoError(t, err)
 

--- a/tests/simulation/simulation_disputes_test.go
+++ b/tests/simulation/simulation_disputes_test.go
@@ -48,6 +48,10 @@ func TestSimulateDisputes(t *testing.T) {
 		err := db.Close()
 		require.NoError(t, err, "failed to close db")
 	}()
+
+	trieDB := store.NewTrie(db)
+	require.NoError(t, err)
+
 	chainDB := store.NewChain(db)
 	require.NoError(t, err)
 
@@ -56,6 +60,7 @@ func TestSimulateDisputes(t *testing.T) {
 		currentState,
 		testBlock,
 		chainDB,
+		trieDB,
 	)
 	require.NoError(t, err)
 

--- a/tests/simulation/simulation_guarantee_test.go
+++ b/tests/simulation/simulation_guarantee_test.go
@@ -50,6 +50,9 @@ func TestSimulateGuarantee(t *testing.T) {
 		require.NoError(t, err, "failed to close db")
 	}()
 
+	trieDB := store.NewTrie(db)
+	require.NoError(t, err)
+
 	chainDB := store.NewChain(db)
 	require.NoError(t, err)
 
@@ -63,6 +66,7 @@ func TestSimulateGuarantee(t *testing.T) {
 		currentState,
 		testBlock,
 		chainDB,
+		trieDB,
 	)
 	require.NoError(t, err)
 

--- a/tests/simulation/simulation_helper_test.go
+++ b/tests/simulation/simulation_helper_test.go
@@ -87,6 +87,7 @@ func TestBlockGenerator(t *testing.T) {
 		currentState,
 		newBlock,
 		chainDB,
+		trieDB,
 	)
 	require.NoError(t, err)
 

--- a/tests/simulation/simulation_preimage_test.go
+++ b/tests/simulation/simulation_preimage_test.go
@@ -47,6 +47,10 @@ func TestSimulatePreimage(t *testing.T) {
 		err := db.Close()
 		require.NoError(t, err, "failed to close db")
 	}()
+
+	trieDB := store.NewTrie(db)
+	require.NoError(t, err)
+
 	chainDB := store.NewChain(db)
 	require.NoError(t, err)
 
@@ -55,6 +59,7 @@ func TestSimulatePreimage(t *testing.T) {
 		currentState,
 		testBlock,
 		chainDB,
+		trieDB,
 	)
 	require.NoError(t, err)
 

--- a/tests/simulation/simulation_test.go
+++ b/tests/simulation/simulation_test.go
@@ -51,6 +51,7 @@ func TestSimulateSAFROLE(t *testing.T) {
 		err := db.Close()
 		require.NoError(t, err, "failed to close db")
 	}()
+
 	trieDB := store.NewTrie(db)
 	require.NoError(t, err)
 
@@ -118,11 +119,12 @@ func TestSimulateSAFROLE(t *testing.T) {
 		t.Logf("block prior state root: %v", hex.EncodeToString(newBlock.Header.PriorStateRoot[:]))
 		t.Logf("block parent hash: %v", hex.EncodeToString(newBlock.Header.ParentHash[:]))
 
-		// Update state
+		// Update state.
 		err = statetransition.UpdateState(
 			currentState,
 			newBlock,
 			chainDB,
+			trieDB,
 		)
 		require.NoError(t, err)
 

--- a/tests/simulation/simulation_ticket_test.go
+++ b/tests/simulation/simulation_ticket_test.go
@@ -43,6 +43,10 @@ func TestSimulateTicket(t *testing.T) {
 		err := db.Close()
 		require.NoError(t, err, "failed to close db")
 	}()
+
+	trieDB := store.NewTrie(db)
+	require.NoError(t, err)
+
 	chainDB := store.NewChain(db)
 	require.NoError(t, err)
 
@@ -51,6 +55,7 @@ func TestSimulateTicket(t *testing.T) {
 		currentState,
 		testBlock,
 		chainDB,
+		trieDB,
 	)
 	require.NoError(t, err)
 

--- a/tests/simulation/ticket_block_001.json
+++ b/tests/simulation/ticket_block_001.json
@@ -1,7 +1,7 @@
 {
     "header": {
         "parent": "0xf34d3d85e230da354db78ef5755a9ed53448847c5a5ccf4f6dec917d544a48c0",
-        "parent_state_root": "0xf985e05b5d128ff353842b1fa1f50764f584c4be3a918c56f78bd7558af43377",
+        "parent_state_root": "0x56082660f30ba1538fea8cca7d2e3c26c7a89a8c060bd53ae27288622de8c3cb",
         "extrinsic_hash": "0xf77bc3fb3a25c8e9b1b26c07a738ddf6e81c65ae60483cbcd851d36aad81dd68",
         "slot": 24,
         "epoch_mark": {
@@ -38,7 +38,7 @@
         "offenders_mark": [],
         "author_index": 2,
         "entropy_source": "0xcf74e8792ab2b10faecd1df7a0a66b93230408c16ba5cb2ec199eeb75e26cbd1ab9bfeedce7d6312dedae8fcabbcb8c5a7fa2f48f0919fdc85a5ebba4d12680785e29524e32ed25baf7fe74af82a0509f1e81247bcfa1d299d48ea775fa7af15",
-        "seal": "0x98853cdfca6cda5238fc065a678421737782fffbc986819b67dfe96786febdba06ded3620679db6a918b0172f3c2f13517ba07253ba2394cab840e7185f58913506a99b19dc645e74a74b1eeb1f3e0f4643e33c0c68101957fa90ab68d944614"
+        "seal": "0x98853cdfca6cda5238fc065a678421737782fffbc986819b67dfe96786febdba9667fad9a258c8e761206ebde413be397a92e377ba319fb495243d474f8f4e1c054c56bd30cbcbce62e55fd9696d16dc8210dfb83c7a84a0fe14b237df85861a"
     },
     "extrinsic": {
         "tickets": [


### PR DESCRIPTION
Add two functions which together do comprehensive block header verification:
- VerifyBlockHeaderBasic, which validates header fields that only
  require the prior state.
- VerifyBlockHeaderSafrole which validates header fields which rely on
  an updated SAFROLE state to proceed.

Right now this is tested as part of safrole simluation, but more tests
to follow in a future PR.

Also:
- Fix up simulation tests which needed to have updated extrinsic hashes
  and parent state roots.
- Skip guarantees simulation test for now, updating the hashes didn't
  help because we also need to generate new signatures for the work
report after updating the state root it should point to.
- Move safrole related STF functions out into it's own file. A separate
  package would have been better, but right now that's not possible
until we structure our packages a little differently to avoid circular
deps.
- Add NextSafroleState function which can be used outside of UpdateState
  to determine the next Safrole state. This function has been moved from
simulation and updated to also potentially handle incoming disputes.
It's used only in simulation for now.
- Offenders marker will be handled later, added a TODO.