### PR TITLE
State key updates for unified storage/preimage meta keys

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -60,9 +60,15 @@ func NewServiceAccount() ServiceAccount {
 	}
 }
 
-// GetGlobalKVItems returns all items stores in globalKV map
+// GetGlobalKVItems returns the global KV map.
 func (sa *ServiceAccount) GetGlobalKVItems() map[statekey.StateKey][]byte {
 	return sa.globalKV
+}
+
+// SetGlobalKVItems sets the global KV map, this should only be used when
+// deserializing state for now.
+func (sa *ServiceAccount) SetGlobalKVItems(globalKV map[statekey.StateKey][]byte) {
+	sa.globalKV = globalKV
 }
 
 // GetStorage retrieves the preimage storage associated with the given key
@@ -80,9 +86,21 @@ func (sa *ServiceAccount) GetTotalNumberOfItems() uint32 {
 	return sa.totalNumberOfItems
 }
 
+// SetTotalNumberOfItems sets `ai` total number of items in storage. This should
+// only be used when deserializing state for now.
+func (sa *ServiceAccount) SetTotalNumberOfItems(n uint32) {
+	sa.totalNumberOfItems = n
+}
+
 // GetTotalNumberOfOctets return `ao` total number of octets/bytes in storage
 func (sa *ServiceAccount) GetTotalNumberOfOctets() uint64 {
 	return sa.totalNumberOfOctets
+}
+
+// SetTotalNumberOfOctets sets `ao` total number of octets/bytes in storage.
+// This should only be used when deserializing state for now.
+func (sa *ServiceAccount) SetTotalNumberOfOctets(n uint64) {
+	sa.totalNumberOfOctets = n
 }
 
 // InsertStorage adds a new storage entry and updates item and octet counters accordingly (9.8 v0.6.7)

--- a/internal/state/serialization/serialization_test.go
+++ b/internal/state/serialization/serialization_test.go
@@ -44,6 +44,11 @@ func TestSerializeState(t *testing.T) {
 		assert.Equal(t, originalService.CreationTimeslot, decodedService.CreationTimeslot)
 		assert.Equal(t, originalService.MostRecentAccumulationTimeslot, decodedService.MostRecentAccumulationTimeslot)
 		assert.Equal(t, originalService.ParentService, decodedService.ParentService)
+
+		assert.Equal(t, originalService.PreimageLookup, decodedService.PreimageLookup)
+		assert.Equal(t, originalService.GetGlobalKVItems(), decodedService.GetGlobalKVItems())
+		assert.Equal(t, originalService.GetTotalNumberOfItems(), decodedService.GetTotalNumberOfItems())
+		assert.Equal(t, originalService.GetTotalNumberOfOctets(), decodedService.GetTotalNumberOfOctets())
 	}
 
 	// Check for extra services in decoded state


### PR DESCRIPTION
- Serialize and deserialize storage and preimage meta keys using the new global kv items map.
- Fix a bug in IsChapterKey which left out the new state component. A chapter key can start with 1-254.
- Expand the serialization test to also check that the service key values are correctly serialized and deserialized.
- Add getters/setters to the global KV service map for serialization purposes.