### PR TITLE
fix: validate preimages using initial service state

### DIFF
--- a/internal/block/preimage.go
+++ b/internal/block/preimage.go
@@ -6,4 +6,5 @@ type Preimage struct {
 	Data         []byte // p
 }
 
+// PreimageExtrinsic EP ∈ ⟦(NS , B)⟧ (eq. 12.38)
 type PreimageExtrinsic []Preimage

--- a/internal/statetransition/state_transition_test.go
+++ b/internal/statetransition/state_transition_test.go
@@ -145,7 +145,7 @@ func TestCalculateIntermediateServiceState(t *testing.T) {
 		}(),
 	}
 
-	newServiceState, err := CalculateIntermediateServiceState(preimages, serviceState, newTimeslot)
+	newServiceState, err := CalculateNewServiceStateWithPreimages(preimages, serviceState, newTimeslot)
 	require.NoError(t, err)
 	require.Equal(t, expectedServiceState, newServiceState)
 }
@@ -168,7 +168,7 @@ func TestCalculateIntermediateServiceStateEmptyPreimages(t *testing.T) {
 
 	expectedServiceState := serviceState
 
-	newServiceState, err := CalculateIntermediateServiceState(block.PreimageExtrinsic{}, serviceState, jamtime.Timeslot(100))
+	newServiceState, err := CalculateNewServiceStateWithPreimages(block.PreimageExtrinsic{}, serviceState, jamtime.Timeslot(100))
 	require.NoError(t, err)
 	require.Equal(t, expectedServiceState, newServiceState)
 }
@@ -200,7 +200,7 @@ func TestCalculateIntermediateServiceStateNonExistentService(t *testing.T) {
 		block.ServiceId(0): sa,
 	}
 
-	newServiceState, err := CalculateIntermediateServiceState(preimages, serviceState, newTimeslot)
+	newServiceState, err := CalculateNewServiceStateWithPreimages(preimages, serviceState, newTimeslot)
 	require.Error(t, err)
 	require.Equal(t, "preimage unneeded", err.Error())
 	require.Nil(t, newServiceState)
@@ -263,7 +263,7 @@ func TestCalculateIntermediateServiceStateMultiplePreimages(t *testing.T) {
 		}(),
 	}
 
-	newServiceState, err := CalculateIntermediateServiceState(preimages, serviceState, newTimeslot)
+	newServiceState, err := CalculateNewServiceStateWithPreimages(preimages, serviceState, newTimeslot)
 	require.NoError(t, err)
 	require.Equal(t, expectedServiceState, newServiceState)
 }
@@ -310,7 +310,7 @@ func TestCalculateIntermediateServiceStateExistingPreimage(t *testing.T) {
 		block.ServiceId(0): sa,
 	}
 
-	newServiceState, err := CalculateIntermediateServiceState(preimages, serviceState, newTimeslot)
+	newServiceState, err := CalculateNewServiceStateWithPreimages(preimages, serviceState, newTimeslot)
 	require.Error(t, err)
 	require.Equal(t, "preimage unneeded", err.Error())
 	require.Nil(t, newServiceState)
@@ -342,7 +342,7 @@ func TestCalculateIntermediateServiceStateExistingMetadata(t *testing.T) {
 		block.ServiceId(0): sa,
 	}
 
-	newServiceState, err := CalculateIntermediateServiceState(preimages, serviceState, newTimeslot)
+	newServiceState, err := CalculateNewServiceStateWithPreimages(preimages, serviceState, newTimeslot)
 	require.Error(t, err)
 	require.Equal(t, "preimage unneeded", err.Error())
 	require.Nil(t, newServiceState)

--- a/internal/statetransition/state_transition_test.go
+++ b/internal/statetransition/state_transition_test.go
@@ -175,7 +175,6 @@ func TestCalculateIntermediateServiceStateEmptyPreimages(t *testing.T) {
 
 func TestCalculateIntermediateServiceStateNonExistentService(t *testing.T) {
 	preimageData := []byte{1, 2, 3}
-	newTimeslot := jamtime.Timeslot(100)
 
 	preimages := block.PreimageExtrinsic{
 		{
@@ -200,10 +199,9 @@ func TestCalculateIntermediateServiceStateNonExistentService(t *testing.T) {
 		block.ServiceId(0): sa,
 	}
 
-	newServiceState, err := CalculateNewServiceStateWithPreimages(preimages, serviceState, newTimeslot)
+	err = ValidatePreimages(preimages, serviceState)
 	require.Error(t, err)
 	require.Equal(t, "preimage unneeded", err.Error())
-	require.Nil(t, newServiceState)
 }
 
 func TestCalculateIntermediateServiceStateMultiplePreimages(t *testing.T) {
@@ -272,7 +270,6 @@ func TestCalculateIntermediateServiceStateExistingPreimage(t *testing.T) {
 	existingPreimageData := []byte{1, 2, 3}
 	existingPreimageHash := crypto.HashData(existingPreimageData)
 	newPreimageData := []byte{4, 5, 6}
-	newTimeslot := jamtime.Timeslot(100)
 
 	preimages := block.PreimageExtrinsic{
 		{
@@ -310,16 +307,14 @@ func TestCalculateIntermediateServiceStateExistingPreimage(t *testing.T) {
 		block.ServiceId(0): sa,
 	}
 
-	newServiceState, err := CalculateNewServiceStateWithPreimages(preimages, serviceState, newTimeslot)
+	err = ValidatePreimages(preimages, serviceState)
 	require.Error(t, err)
 	require.Equal(t, "preimage unneeded", err.Error())
-	require.Nil(t, newServiceState)
 }
 
 func TestCalculateIntermediateServiceStateExistingMetadata(t *testing.T) {
 	preimageData := []byte{1, 2, 3}
 	preimageHash := crypto.HashData(preimageData)
-	newTimeslot := jamtime.Timeslot(100)
 
 	preimages := block.PreimageExtrinsic{
 		{
@@ -342,10 +337,9 @@ func TestCalculateIntermediateServiceStateExistingMetadata(t *testing.T) {
 		block.ServiceId(0): sa,
 	}
 
-	newServiceState, err := CalculateNewServiceStateWithPreimages(preimages, serviceState, newTimeslot)
+	err = ValidatePreimages(preimages, serviceState)
 	require.Error(t, err)
 	require.Equal(t, "preimage unneeded", err.Error())
-	require.Nil(t, newServiceState)
 }
 
 func TestCalculateIntermediateCoreAssignmentsFromExtrinsics(t *testing.T) {

--- a/tests/integration/preimages_test.go
+++ b/tests/integration/preimages_test.go
@@ -131,7 +131,13 @@ func TestPreimage(t *testing.T) {
 			preimages := mapPreimages(t, data.Input.Preimages)
 
 			newTimeSlot := jamtime.Timeslot(data.Input.Slot)
-			newServiceState, err := statetransition.CalculateIntermediateServiceState(preimages, preServiceState, newTimeSlot)
+			err = statetransition.ValidatePreimages(preimages, preServiceState)
+			if data.Output.Err != "" {
+				require.Error(t, err)
+				require.EqualError(t, err, strings.ReplaceAll(data.Output.Err, "_", " "))
+				return
+			}
+			newServiceState, err := statetransition.CalculateNewServiceStateWithPreimages(preimages, preServiceState, newTimeSlot)
 			if data.Output.Err != "" {
 				require.Error(t, err)
 				require.EqualError(t, err, strings.ReplaceAll(data.Output.Err, "_", " "))


### PR DESCRIPTION
separate the preimage integration in two steps 
1. validating that the preimages are ordered, unique and solicited by the initial service and 
2. integrating the solicited preimages

also updates the comments to v0.7.0
