### PR TITLE
fix: safrole unexpected author

### DIFF
--- a/internal/state/block_seal.go
+++ b/internal/state/block_seal.go
@@ -499,7 +499,7 @@ func VerifyBlockSignatures(
 	// start.
 	case crypto.BandersnatchPublicKey:
 		if tok != publicKey {
-			return false, nil
+			return false, errors.New("unexpected author")
 		}
 
 		ok, _ := bandersnatch.Verify(

--- a/pkg/conformance/node.go
+++ b/pkg/conformance/node.go
@@ -113,7 +113,11 @@ func (n *Node) handleConnection(conn net.Conn) {
 			} else if strings.Contains(err.Error(), "bad validator index") {
 				responseMsg = NewMessage(Error{Message: []byte("Chain error: block execution failure: assurances error: bad attestation validator index")})
 			} else if strings.Contains(err.Error(), "block seal or vrf signature is invalid") {
+				responseMsg = NewMessage(Error{Message: []byte("Chain error: block header verification failure: BadSealSignature")})
+			} else if strings.Contains(err.Error(), "unexpected author") {
 				responseMsg = NewMessage(Error{Message: []byte("Chain error: block header verification failure: UnexpectedAuthor")})
+			} else if strings.Contains(err.Error(), "epoch marker") {
+				responseMsg = NewMessage(Error{Message: []byte("Chain error: block header verification failure: InvalidEpochMark")})
 			} else {
 				return
 			}


### PR DESCRIPTION
If we're in a fallback mode, and the author index is incorrect, we should return an "unexpected author' error instead of just failing signature validation.

This is because during fallback mode we know the author's public key, and we know the public key that we expect in the sealing keys.

Also
- Map epoch marker errors